### PR TITLE
Add Helm chart for turnstile-appcheck-gateway

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,36 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Set up Helm
+        if: steps.version.outputs.release_required == 'true'
+        uses: azure/setup-helm@v4
+
+      - name: Package Helm chart
+        if: steps.version.outputs.release_required == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p dist/charts
+          helm lint ./deploy/chart
+          helm package ./deploy/chart \
+            --version "${{ steps.version.outputs.docker_tag }}" \
+            --app-version "${{ steps.version.outputs.docker_tag }}" \
+            --destination dist/charts
+
+      - name: Log in to GHCR for Helm
+        if: steps.version.outputs.release_required == 'true'
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push Helm chart to GHCR OCI registry
+        if: steps.version.outputs.release_required == 'true'
+        run: |
+          set -euo pipefail
+          helm push "dist/charts/turnstile-appcheck-gateway-${{ steps.version.outputs.docker_tag }}.tgz" \
+            oci://ghcr.io/michibiki-io/charts
+
       - name: Generate release notes
         if: steps.version.outputs.release_required == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist/charts
-          helm lint ./deploy/chart
+          helm lint ./deploy/chart \
+            --set-string secrets.TURNSTILE_SECRET_KEY=dummy \
+            --set-string secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=dummy
           helm package ./deploy/chart \
             --version "${{ steps.version.outputs.docker_tag }}" \
             --app-version "${{ steps.version.outputs.docker_tag }}" \

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: turnstile-appcheck-gateway
+description: Helm chart for deploying the Turnstile and Firebase App Check gateway
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/michibiki-io/turnstile-appcheck-gateway
+sources:
+  - https://github.com/michibiki-io/turnstile-appcheck-gateway
+keywords:
+  - turnstile
+  - firebase
+  - app-check
+  - forwardauth
+  - traefik
+  - audit-log
+  - admin-dashboard
+  - kubernetes
+maintainers:
+  - name: michibiki-io
+    url: https://github.com/michibiki-io

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -1,0 +1,284 @@
+# turnstile-appcheck-gateway Helm Chart
+
+This chart installs `turnstile-appcheck-gateway`, a Go/Gin gateway that bridges Cloudflare Turnstile and Firebase App Check Custom Provider. It exposes:
+
+- `POST {SUBPATH}/api/v1/exchange` for frontend token exchange
+- `ANY {SUBPATH}/api/v1/verify` for Traefik forwardAuth verification
+- `GET /healthz`
+- `GET /readyz`
+- `GET {SUBPATH}/admin/` and `GET {SUBPATH}/_admin/api/v1/...` when the admin dashboard is enabled
+
+The chart separates non-sensitive runtime configuration into a `ConfigMap` and sensitive values into a `Secret`. It also supports SQLite audit log persistence with a PVC and an ephemeral `emptyDir` mode.
+
+## Prerequisites
+
+- Helm 3.8 or later
+- Kubernetes 1.26 or later
+- Access to `ghcr.io/michibiki-io/charts/turnstile-appcheck-gateway` for OCI installs
+- Cloudflare Turnstile secret key
+- Firebase project ID
+- Firebase App ID or Firebase App Resource
+- Google service account JSON or base64-encoded JSON
+
+`GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` is recommended. The application prefers it over `GOOGLE_SERVICE_ACCOUNT_JSON` when both are set.
+
+## Install from Local Path
+
+```bash
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+```
+
+`config.FIREBASE_PROJECT_ID` is required in real deployments. Set either `config.FIREBASE_APP_ID` or `config.FIREBASE_APP_RESOURCE`.
+
+## Install from OCI Registry
+
+```bash
+helm install turnstile-appcheck-gateway \
+  oci://ghcr.io/michibiki-io/charts/turnstile-appcheck-gateway \
+  --version 0.1.0 \
+  --namespace appcheck \
+  --create-namespace \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+```
+
+The published chart version and `appVersion` are expected to be overridden during release packaging. If `image.tag` is empty, the chart uses `.Chart.AppVersion`.
+
+## Upgrade
+
+```bash
+helm upgrade turnstile-appcheck-gateway \
+  oci://ghcr.io/michibiki-io/charts/turnstile-appcheck-gateway \
+  --version 0.1.0 \
+  --namespace appcheck
+```
+
+## Uninstall
+
+```bash
+helm uninstall turnstile-appcheck-gateway --namespace appcheck
+```
+
+## Ingress Example
+
+Keep `ingress.hosts[].paths[].path` aligned with `config.APPCHECK_SUBPATH`.
+
+```bash
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set config.APPCHECK_SUBPATH=/appcheck \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64" \
+  --set ingress.enabled=true \
+  --set ingress.className=traefik \
+  --set ingress.hosts[0].host=appcheck.example.com \
+  --set ingress.hosts[0].paths[0].path=/appcheck \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+With the defaults, these endpoints become reachable below the same ingress path:
+
+- `/appcheck/api/v1/exchange`
+- `/appcheck/api/v1/verify`
+- `/appcheck/admin/`
+- `/appcheck/_admin/api/v1/...`
+
+## Traefik forwardAuth Example
+
+This chart deploys the gateway itself. Other services can use its `/verify` endpoint as a Traefik `forwardAuth` backend.
+
+```yaml
+http:
+  middlewares:
+    appcheck-forward-auth:
+      forwardAuth:
+        address: "http://turnstile-appcheck-gateway.appcheck.svc.cluster.local:80/appcheck/api/v1/verify"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-AppCheck-Verified
+          - X-AppCheck-AppID
+```
+
+`VERIFY_SUCCESS_STATUS` must stay a 2xx status and `VERIFY_FAILURE_STATUS` must stay a non-2xx status.
+
+## Admin Dashboard
+
+The default dashboard URL is:
+
+```text
+https://appcheck.example.com/appcheck/admin/
+```
+
+The default admin API prefix is:
+
+```text
+https://appcheck.example.com/appcheck/_admin/api/v1/...
+```
+
+Enable or adjust it with values like:
+
+```bash
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64" \
+  --set config.ADMIN_DASHBOARD_ENABLED=true \
+  --set config.ADMIN_BASE_PATH=/admin
+```
+
+## Header Auth Example for Admin Dashboard
+
+`ADMIN_AUTH_MODE=header` assumes a trusted upstream authentication layer injects identity headers such as `X-Forwarded-User`, `X-Forwarded-Email`, and `X-Forwarded-Groups`.
+
+```bash
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set ingress.enabled=true \
+  --set ingress.className=traefik \
+  --set ingress.annotations."traefik\\.ingress\\.kubernetes\\.io/router\\.middlewares"=appcheck-admin-auth@kubernetescrd \
+  --set ingress.hosts[0].host=appcheck.example.com \
+  --set ingress.hosts[0].paths[0].path=/appcheck \
+  --set ingress.hosts[0].paths[0].pathType=Prefix \
+  --set config.ADMIN_AUTH_MODE=header \
+  --set config.ADMIN_AUTH_USER_HEADER=X-Forwarded-User \
+  --set config.ADMIN_AUTH_EMAIL_HEADER=X-Forwarded-Email \
+  --set config.ADMIN_AUTH_GROUPS_HEADER=X-Forwarded-Groups \
+  --set config.ADMIN_ALLOWED_GROUPS=gateway-admins \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+```
+
+Only identities matching `ADMIN_ALLOWED_USERS` or `ADMIN_ALLOWED_GROUPS` are allowed.
+
+## Warning for `ADMIN_AUTH_MODE=none`
+
+`ADMIN_AUTH_MODE=none` disables service-side dashboard authentication. Use it only when ingress, reverse proxy, VPN, Basic Auth, Authelia, oauth2-proxy, or another trusted upstream control already protects `/admin` and `/_admin`.
+
+Do not expose `ADMIN_AUTH_MODE=none` directly to the public internet.
+
+## Audit Log Persistence with SQLite
+
+When `config.AUDIT_ENABLED=true`, the application stores audit events in SQLite at `config.AUDIT_SQLITE_PATH`. The chart mounts `/var/lib/turnstile-appcheck-gateway` as writable storage and defaults to PVC-backed persistence.
+
+```bash
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set persistence.enabled=true \
+  --set persistence.size=1Gi \
+  --set config.AUDIT_ENABLED=true \
+  --set config.AUDIT_SQLITE_PATH=/var/lib/turnstile-appcheck-gateway/audit.db \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+```
+
+For SQLite persistence, a single replica is recommended. The chart can render multiple replicas, but SQLite state and audit history are local to the mounted filesystem and are not a distributed datastore.
+
+`AUDIT_RETENTION_DAYS=0` disables retention cleanup.
+
+The audit log is designed not to store secret values, tokens, service account JSON, `Authorization` headers, cookies, or raw request bodies.
+
+## Ephemeral Audit Log Example
+
+If you do not want a PVC, disable persistence. The chart will mount `emptyDir` at `/var/lib/turnstile-appcheck-gateway`.
+
+```bash
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set persistence.enabled=false \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456' \
+  --set secrets.TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --set secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+```
+
+In this mode, audit history is lost when the Pod restarts or is rescheduled.
+
+## External Secret Example
+
+Use `existingSecret` when another controller or manual process manages sensitive values.
+
+```bash
+kubectl create namespace appcheck
+
+kubectl create secret generic turnstile-appcheck-gateway-secret \
+  --namespace appcheck \
+  --from-literal=TURNSTILE_SECRET_KEY="$TURNSTILE_SECRET_KEY" \
+  --from-literal=GOOGLE_SERVICE_ACCOUNT_JSON_BASE64="$GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+
+helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
+  --namespace appcheck \
+  --create-namespace \
+  --set existingSecret=turnstile-appcheck-gateway-secret \
+  --set config.FIREBASE_PROJECT_ID=my-firebase-project \
+  --set config.FIREBASE_APP_ID='1:1234567890:web:abcdef123456'
+```
+
+## Creating `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`
+
+Linux:
+
+```bash
+base64 -w 0 firebase-service-account.json
+```
+
+macOS:
+
+```bash
+base64 < firebase-service-account.json | tr -d '\n'
+```
+
+## Rate Limit Notes
+
+`RATE_LIMIT_ENABLED`, `RATE_LIMIT_REQUESTS`, and `RATE_LIMIT_WINDOW` control an in-memory limiter on `/exchange` and `/verify`.
+
+- Counters are per Pod.
+- Multi-replica deployments increase total effective capacity.
+- If you need a strict global limit, enforce it in ingress, API gateway, or WAF layers.
+
+## HPA Notes
+
+The chart supports `autoscaling/v2` HPA objects.
+
+- HPA scaling changes effective in-memory rate-limit capacity because each Pod has independent counters.
+- HPA does not make SQLite audit state distributed.
+
+## Major Values
+
+- `config.APPCHECK_SUBPATH`: public subpath for `/exchange`, `/verify`, `/admin`, and `/_admin`
+- `config.HEALTH_PATH` and `config.READY_PATH`: root-level probe paths; do not prefix them with `APPCHECK_SUBPATH`
+- `config.FIREBASE_PROJECT_ID`: required
+- `config.FIREBASE_APP_ID` or `config.FIREBASE_APP_RESOURCE`: one is required
+- `config.ADMIN_*`: admin dashboard and header-auth behavior
+- `config.AUDIT_*`: SQLite audit logging behavior
+- `config.RATE_LIMIT_*`: in-memory rate limiting behavior
+- `secrets.TURNSTILE_SECRET_KEY`: required unless `existingSecret` is used
+- `secrets.GOOGLE_SERVICE_ACCOUNT_JSON` or `secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`: one is required unless `existingSecret` is used
+- `persistence.enabled`: switch between PVC-backed audit storage and ephemeral `emptyDir`
+- `securityContext.readOnlyRootFilesystem`: defaults to `true`; the chart still mounts writable `/tmp` and `/var/lib/turnstile-appcheck-gateway`
+
+## Listing Published Versions
+
+```bash
+oras repo tags ghcr.io/michibiki-io/charts/turnstile-appcheck-gateway
+```

--- a/deploy/chart/templates/NOTES.txt
+++ b/deploy/chart/templates/NOTES.txt
@@ -1,0 +1,59 @@
+Release name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Service: {{ include "turnstile-appcheck-gateway.fullname" . }}
+Service port: {{ .Values.service.port }}
+
+Public endpoints:
+  Exchange: {{ include "turnstile-appcheck-gateway.appCheckSubpath" . }}/api/v1/exchange
+  Verify: {{ include "turnstile-appcheck-gateway.appCheckSubpath" . }}/api/v1/verify
+  Health: {{ include "turnstile-appcheck-gateway.healthPath" . }}
+  Readiness: {{ include "turnstile-appcheck-gateway.readyPath" . }}
+
+{{- if eq (lower (trim (default "true" (index .Values.config "ADMIN_DASHBOARD_ENABLED")))) "true" }}
+Admin dashboard: {{ include "turnstile-appcheck-gateway.adminDashboardPath" . }}
+Admin API prefix: {{ include "turnstile-appcheck-gateway.adminAPIPath" . }}
+{{- else }}
+Admin dashboard: disabled
+Admin API: disabled
+{{- end }}
+
+Audit SQLite path: {{ default "/var/lib/turnstile-appcheck-gateway/audit.db" (index .Values.config "AUDIT_SQLITE_PATH") }}
+Persistence:
+  Enabled: {{ .Values.persistence.enabled }}
+  Mount path: {{ include "turnstile-appcheck-gateway.dataMountPath" . }}
+  {{- if .Values.persistence.enabled }}
+  Claim: {{ include "turnstile-appcheck-gateway.pvcName" . }}
+  {{- else }}
+  Backend: emptyDir (audit history is lost when the Pod restarts)
+  {{- end }}
+
+{{- if .Values.ingress.enabled }}
+Ingress URLs:
+{{- range $host := .Values.ingress.hosts }}
+  {{- $paths := $host.paths | default (list (dict "path" (include "turnstile-appcheck-gateway.appCheckSubpath" $) "pathType" "Prefix")) }}
+  {{- range $path := $paths }}
+  - {{- if $.Values.ingress.tls }} https://{{ else }} http://{{ end }}{{ $host.host }}{{ $path.path }}
+  {{- end }}
+{{- end }}
+{{- else }}
+Ingress is disabled.
+To access the service locally:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "turnstile-appcheck-gateway.fullname" . }} 8080:{{ .Values.service.port }}
+{{- end }}
+
+{{- if .Values.existingSecret }}
+Secret source: existing Secret {{ .Values.existingSecret }}
+{{- else }}
+Secret source: created by this chart as {{ include "turnstile-appcheck-gateway.secretName" . }}
+{{- end }}
+
+Required sensitive keys:
+  - TURNSTILE_SECRET_KEY
+  - GOOGLE_SERVICE_ACCOUNT_JSON or GOOGLE_SERVICE_ACCOUNT_JSON_BASE64
+
+{{- if eq (lower (trim (default "header" (index .Values.config "ADMIN_AUTH_MODE")))) "none" }}
+WARNING:
+  ADMIN_AUTH_MODE=none disables service-side admin authentication.
+  Protect {{ include "turnstile-appcheck-gateway.adminDashboardPath" . }} and {{ include "turnstile-appcheck-gateway.adminAPIPath" . }} with a trusted upstream auth layer.
+  Do not expose these paths directly to the public internet.
+{{- end }}

--- a/deploy/chart/templates/NOTES.txt
+++ b/deploy/chart/templates/NOTES.txt
@@ -9,7 +9,7 @@ Public endpoints:
   Health: {{ include "turnstile-appcheck-gateway.healthPath" . }}
   Readiness: {{ include "turnstile-appcheck-gateway.readyPath" . }}
 
-{{- if eq (lower (trim (default "true" (index .Values.config "ADMIN_DASHBOARD_ENABLED")))) "true" }}
+{{- if eq (lower (trim (printf "%v" (default "true" (index .Values.config "ADMIN_DASHBOARD_ENABLED"))))) "true" }}
 Admin dashboard: {{ include "turnstile-appcheck-gateway.adminDashboardPath" . }}
 Admin API prefix: {{ include "turnstile-appcheck-gateway.adminAPIPath" . }}
 {{- else }}
@@ -17,7 +17,7 @@ Admin dashboard: disabled
 Admin API: disabled
 {{- end }}
 
-Audit SQLite path: {{ default "/var/lib/turnstile-appcheck-gateway/audit.db" (index .Values.config "AUDIT_SQLITE_PATH") }}
+Audit SQLite path: {{ printf "%v" (default "/var/lib/turnstile-appcheck-gateway/audit.db" (index .Values.config "AUDIT_SQLITE_PATH")) }}
 Persistence:
   Enabled: {{ .Values.persistence.enabled }}
   Mount path: {{ include "turnstile-appcheck-gateway.dataMountPath" . }}
@@ -51,7 +51,7 @@ Required sensitive keys:
   - TURNSTILE_SECRET_KEY
   - GOOGLE_SERVICE_ACCOUNT_JSON or GOOGLE_SERVICE_ACCOUNT_JSON_BASE64
 
-{{- if eq (lower (trim (default "header" (index .Values.config "ADMIN_AUTH_MODE")))) "none" }}
+{{- if eq (lower (trim (printf "%v" (default "header" (index .Values.config "ADMIN_AUTH_MODE"))))) "none" }}
 WARNING:
   ADMIN_AUTH_MODE=none disables service-side admin authentication.
   Protect {{ include "turnstile-appcheck-gateway.adminDashboardPath" . }} and {{ include "turnstile-appcheck-gateway.adminAPIPath" . }} with a trusted upstream auth layer.

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,143 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "turnstile-appcheck-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "turnstile-appcheck-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "turnstile-appcheck-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "turnstile-appcheck-gateway.labels" -}}
+helm.sh/chart: {{ include "turnstile-appcheck-gateway.chart" . }}
+app.kubernetes.io/name: {{ include "turnstile-appcheck-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "turnstile-appcheck-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "turnstile-appcheck-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "turnstile-appcheck-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "turnstile-appcheck-gateway.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the ConfigMap name.
+*/}}
+{{- define "turnstile-appcheck-gateway.configMapName" -}}
+{{- printf "%s-config" (include "turnstile-appcheck-gateway.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Create the Secret name.
+*/}}
+{{- define "turnstile-appcheck-gateway.secretName" -}}
+{{- default (printf "%s-secret" (include "turnstile-appcheck-gateway.fullname" .)) .Values.existingSecret -}}
+{{- end -}}
+
+{{/*
+Create the PVC name.
+*/}}
+{{- define "turnstile-appcheck-gateway.pvcName" -}}
+{{- default (include "turnstile-appcheck-gateway.fullname" .) .Values.persistence.existingClaim -}}
+{{- end -}}
+
+{{/*
+Normalize the App Check subpath.
+*/}}
+{{- define "turnstile-appcheck-gateway.appCheckSubpath" -}}
+{{- $subpath := trim (default "/appcheck" (index .Values.config "APPCHECK_SUBPATH")) -}}
+{{- if eq $subpath "" -}}
+/appcheck
+{{- else if hasPrefix "/" $subpath -}}
+{{- trimSuffix "/" $subpath | default "/" -}}
+{{- else -}}
+/{{ trimSuffix "/" $subpath }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Normalize the admin base path.
+*/}}
+{{- define "turnstile-appcheck-gateway.adminBasePath" -}}
+{{- $base := trim (default "/admin" (index .Values.config "ADMIN_BASE_PATH")) -}}
+{{- if eq $base "" -}}
+/admin
+{{- else if hasPrefix "/" $base -}}
+{{- trimSuffix "/" $base | default "/admin" -}}
+{{- else -}}
+/{{ trimSuffix "/" $base }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the configured health path.
+*/}}
+{{- define "turnstile-appcheck-gateway.healthPath" -}}
+{{- default "/healthz" (index .Values.config "HEALTH_PATH") -}}
+{{- end -}}
+
+{{/*
+Return the configured readiness path.
+*/}}
+{{- define "turnstile-appcheck-gateway.readyPath" -}}
+{{- default "/readyz" (index .Values.config "READY_PATH") -}}
+{{- end -}}
+
+{{/*
+Return the writable data mount path.
+*/}}
+{{- define "turnstile-appcheck-gateway.dataMountPath" -}}
+{{- default "/var/lib/turnstile-appcheck-gateway" .Values.persistence.mountPath -}}
+{{- end -}}
+
+{{/*
+Return the admin dashboard path under the public subpath.
+*/}}
+{{- define "turnstile-appcheck-gateway.adminDashboardPath" -}}
+{{- printf "%s%s/" (include "turnstile-appcheck-gateway.appCheckSubpath" .) (include "turnstile-appcheck-gateway.adminBasePath" .) -}}
+{{- end -}}
+
+{{/*
+Return the admin API base path under the public subpath.
+*/}}
+{{- define "turnstile-appcheck-gateway.adminAPIPath" -}}
+{{- printf "%s/_admin/api/v1" (include "turnstile-appcheck-gateway.appCheckSubpath" .) -}}
+{{- end -}}

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -83,7 +83,7 @@ Create the PVC name.
 Normalize the App Check subpath.
 */}}
 {{- define "turnstile-appcheck-gateway.appCheckSubpath" -}}
-{{- $subpath := trim (default "/appcheck" (index .Values.config "APPCHECK_SUBPATH")) -}}
+{{- $subpath := trim (printf "%v" (default "/appcheck" (index .Values.config "APPCHECK_SUBPATH"))) -}}
 {{- if eq $subpath "" -}}
 /appcheck
 {{- else if hasPrefix "/" $subpath -}}
@@ -97,7 +97,7 @@ Normalize the App Check subpath.
 Normalize the admin base path.
 */}}
 {{- define "turnstile-appcheck-gateway.adminBasePath" -}}
-{{- $base := trim (default "/admin" (index .Values.config "ADMIN_BASE_PATH")) -}}
+{{- $base := trim (printf "%v" (default "/admin" (index .Values.config "ADMIN_BASE_PATH"))) -}}
 {{- if eq $base "" -}}
 /admin
 {{- else if hasPrefix "/" $base -}}
@@ -111,14 +111,14 @@ Normalize the admin base path.
 Return the configured health path.
 */}}
 {{- define "turnstile-appcheck-gateway.healthPath" -}}
-{{- default "/healthz" (index .Values.config "HEALTH_PATH") -}}
+{{- printf "%v" (default "/healthz" (index .Values.config "HEALTH_PATH")) -}}
 {{- end -}}
 
 {{/*
 Return the configured readiness path.
 */}}
 {{- define "turnstile-appcheck-gateway.readyPath" -}}
-{{- default "/readyz" (index .Values.config "READY_PATH") -}}
+{{- printf "%v" (default "/readyz" (index .Values.config "READY_PATH")) -}}
 {{- end -}}
 
 {{/*

--- a/deploy/chart/templates/configmap.yaml
+++ b/deploy/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.configMapName" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+data:
+  {{- range $key := keys .Values.config | sortAlpha }}
+  {{ $key }}: {{ index $.Values.config $key | quote }}
+  {{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.fullname" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- if .Values.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "turnstile-appcheck-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.existingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "turnstile-appcheck-gateway.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "turnstile-appcheck-gateway.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "turnstile-appcheck-gateway.name" . }}
+          {{- $defaultLivenessProbe := dict "httpGet" (dict "path" (include "turnstile-appcheck-gateway.healthPath" .) "port" "http") "initialDelaySeconds" 10 "periodSeconds" 10 "timeoutSeconds" 2 "failureThreshold" 3 }}
+          {{- $defaultReadinessProbe := dict "httpGet" (dict "path" (include "turnstile-appcheck-gateway.readyPath" .) "port" "http") "initialDelaySeconds" 5 "periodSeconds" 5 "timeoutSeconds" 2 "failureThreshold" 3 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "turnstile-appcheck-gateway.configMapName" . }}
+            - secretRef:
+                name: {{ include "turnstile-appcheck-gateway.secretName" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          livenessProbe:
+            {{- toYaml (mergeOverwrite (deepCopy $defaultLivenessProbe) .Values.livenessProbe) | nindent 12 }}
+          readinessProbe:
+            {{- toYaml (mergeOverwrite (deepCopy $defaultReadinessProbe) .Values.readinessProbe) | nindent 12 }}
+          {{- with .Values.startupProbe }}
+          {{- $defaultStartupProbe := dict "httpGet" (dict "path" (include "turnstile-appcheck-gateway.healthPath" $) "port" "http") }}
+          startupProbe:
+            {{- toYaml (mergeOverwrite (deepCopy $defaultStartupProbe) .) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: {{ include "turnstile-appcheck-gateway.dataMountPath" . }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "turnstile-appcheck-gateway.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/chart/templates/hpa.yaml
+++ b/deploy/chart/templates/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.autoscaling.enabled }}
+{{- $hasCpuMetric := not (empty .Values.autoscaling.targetCPUUtilizationPercentage) }}
+{{- $hasMemoryMetric := not (empty .Values.autoscaling.targetMemoryUtilizationPercentage) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.fullname" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "turnstile-appcheck-gateway.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if or $hasCpuMetric $hasMemoryMetric }}
+  metrics:
+    {{- if $hasCpuMetric }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $hasMemoryMetric }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/templates/ingress.yaml
+++ b/deploy/chart/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.fullname" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host.host | quote }}
+      http:
+        paths:
+          {{- $paths := $host.paths | default (list (dict "path" (include "turnstile-appcheck-gateway.appCheckSubpath" $) "pathType" "Prefix")) }}
+          {{- range $path := $paths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType }}
+            backend:
+              service:
+                name: {{ include "turnstile-appcheck-gateway.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/templates/pvc.yaml
+++ b/deploy/chart/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.pvcName" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/templates/secret.yaml
+++ b/deploy/chart/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if not .Values.existingSecret }}
+{{- $turnstileSecret := trim (default "" .Values.secrets.TURNSTILE_SECRET_KEY) }}
+{{- $serviceAccountJSON := trim (default "" .Values.secrets.GOOGLE_SERVICE_ACCOUNT_JSON) }}
+{{- $serviceAccountJSONBase64 := trim (default "" .Values.secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64) }}
+{{- if not $turnstileSecret }}
+{{- fail "secrets.TURNSTILE_SECRET_KEY is required unless existingSecret is set" }}
+{{- end }}
+{{- if and (not $serviceAccountJSON) (not $serviceAccountJSONBase64) }}
+{{- fail "secrets.GOOGLE_SERVICE_ACCOUNT_JSON or secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 is required unless existingSecret is set" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.secretName" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key := keys .Values.secrets | sortAlpha }}
+  {{ $key }}: {{ index $.Values.secrets $key | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -1,0 +1,30 @@
+{{- if and (eq .Values.service.type "ExternalName") (not .Values.service.externalName) }}
+{{- fail "service.externalName is required when service.type is ExternalName" }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.fullname" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "ExternalName" }}
+  externalName: {{ .Values.service.externalName | quote }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+  {{- else }}
+  selector:
+    {{- include "turnstile-appcheck-gateway.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  {{- end }}

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "turnstile-appcheck-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "turnstile-appcheck-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -1,0 +1,350 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "service": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "ExternalName"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "service": {
+            "required": [
+              "externalName"
+            ],
+            "properties": {
+              "externalName": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      },
+      "required": [
+        "repository",
+        "tag",
+        "pullPolicy"
+      ]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer",
+            "ExternalName"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "externalName": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "port"
+      ]
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "pathType"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "host"
+            ]
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "resources": {
+      "type": "object"
+    },
+    "livenessProbe": {
+      "type": "object"
+    },
+    "readinessProbe": {
+      "type": "object"
+    },
+    "startupProbe": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        }
+      },
+      "required": [
+        "enabled",
+        "minReplicas",
+        "maxReplicas"
+      ]
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "size": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "mountPath": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "enabled",
+        "size",
+        "mountPath"
+      ]
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "existingSecret": {
+      "type": "string"
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "required": [
+    "replicaCount",
+    "image",
+    "service",
+    "ingress",
+    "autoscaling",
+    "persistence",
+    "config",
+    "secrets",
+    "existingSecret",
+    "extraEnv",
+    "extraEnvFrom",
+    "extraVolumes",
+    "extraVolumeMounts"
+  ]
+}

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -295,7 +295,12 @@
     "config": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "boolean",
+          "integer",
+          "number"
+        ]
       }
     },
     "secrets": {

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,143 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/michibiki-io/turnstile-appcheck-gateway
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+  externalName: ""
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: appcheck.example.com
+      paths:
+        - path: /appcheck
+          pathType: Prefix
+  tls: []
+
+resources: {}
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+startupProbe: null
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: null
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+  mountPath: /var/lib/turnstile-appcheck-gateway
+
+config:
+  APPCHECK_SUBPATH: "/appcheck"
+  HTTP_ADDR: ":8080"
+  TURNSTILE_SITEVERIFY_URL: "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+  LOG_LEVEL: "info"
+  REQUEST_TIMEOUT: "10s"
+  APPCHECK_TOKEN_TTL: "30m"
+  ALLOWED_EXCHANGE_ORIGINS: ""
+  TRUST_PROXY_HEADERS: "false"
+  VERIFY_HEADER_NAME: "X-Firebase-AppCheck"
+  VERIFY_SUCCESS_STATUS: "204"
+  VERIFY_FAILURE_STATUS: "401"
+  HEALTH_PATH: "/healthz"
+  READY_PATH: "/readyz"
+
+  FIREBASE_PROJECT_ID: ""
+  FIREBASE_APP_ID: ""
+  FIREBASE_APP_RESOURCE: ""
+
+  ADMIN_DASHBOARD_ENABLED: "true"
+  ADMIN_BASE_PATH: "/admin"
+  ADMIN_AUDIT_TIMESTAMP_FORMAT: "2006-01-02 15:04:05 MST"
+  ADMIN_AUDIT_TIMESTAMP_TIMEZONE: "Asia/Tokyo"
+  ADMIN_AUTH_MODE: "header"
+  ADMIN_AUTH_USER_HEADER: "X-Forwarded-User"
+  ADMIN_AUTH_EMAIL_HEADER: "X-Forwarded-Email"
+  ADMIN_AUTH_GROUPS_HEADER: "X-Forwarded-Groups"
+  ADMIN_ALLOWED_USERS: ""
+  ADMIN_ALLOWED_GROUPS: "gateway-admins"
+
+  AUDIT_ENABLED: "true"
+  AUDIT_SQLITE_PATH: "/var/lib/turnstile-appcheck-gateway/audit.db"
+  AUDIT_RETENTION_DAYS: "90"
+
+  RATE_LIMIT_ENABLED: "true"
+  RATE_LIMIT_REQUESTS: "120"
+  RATE_LIMIT_WINDOW: "1m"
+
+secrets:
+  TURNSTILE_SECRET_KEY: ""
+  GOOGLE_SERVICE_ACCOUNT_JSON: ""
+  GOOGLE_SERVICE_ACCOUNT_JSON_BASE64: ""
+
+existingSecret: ""
+
+extraEnv: []
+extraEnvFrom: []
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
### Summary
- English
  - Add a Helm chart under `deploy/chart` for `turnstile-appcheck-gateway`, including templates, schema, values, documentation, and release workflow packaging updates.
- Japanese
  - `turnstile-appcheck-gateway` 向けに `deploy/chart` 配下の Helm Chart 一式を追加し、templates、schema、values、README、release workflow の packaging 更新を含める。
### Why
- English
  - Kubernetes deployments need an installable Helm chart, and the release workflow must push the chart artifact using the correct service name.
- Japanese
  - Kubernetes デプロイには install 可能な Helm Chart が必要であり、release workflow でも正しいサービス名で chart artifact を push できる必要がある。
