### PR TITLE
Add e2e and release validation flows

### DIFF
--- a/.github/workflows/compose-e2e.yml
+++ b/.github/workflows/compose-e2e.yml
@@ -1,0 +1,40 @@
+name: compose-e2e
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - "frontend/**"
+      - "dev/**"
+      - "internal/**"
+      - "cmd/**"
+      - "scripts/e2e-smoke-mock.sh"
+      - "dev/docker-compose.yml"
+      - "dev/docker-compose.e2e.yml"
+      - "Makefile"
+      - ".github/workflows/compose-e2e.yml"
+
+jobs:
+  compose-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run compose mock e2e
+        run: |
+          make compose-e2e-mock
+
+      - name: Show compose logs on failure
+        if: failure()
+        run: |
+          docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml ps || true
+          docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml logs || true
+
+      - name: Stop compose stack
+        if: always()
+        run: |
+          make compose-e2e-down

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -1,0 +1,34 @@
+name: helm-e2e
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - "frontend/**"
+      - "deploy/chart/**"
+      - "internal/**"
+      - "cmd/**"
+      - "scripts/helm-e2e-kind.sh"
+      - "scripts/e2e-smoke-mock.sh"
+      - "Makefile"
+      - ".github/workflows/helm-e2e.yml"
+
+jobs:
+  helm-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up kind
+        uses: engineerd/setup-kind@v0.6.2
+
+      - name: Run Helm chart mock e2e on kind
+        run: |
+          KEEP_ON_FAILURE=false make e2e-kind-mock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,22 @@ jobs:
           set -euo pipefail
           echo "No release is required for PR #${PR_NUMBER}."
 
+      - name: Run release integration e2e before release
+        if: steps.version.outputs.release_required == 'true'
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_APP_RESOURCE: ${{ secrets.FIREBASE_APP_RESOURCE }}
+          GOOGLE_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 }}
+          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+          REAL_E2E_TURNSTILE_TOKEN: ${{ secrets.REAL_E2E_TURNSTILE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Default path is dummy Turnstile + real Firebase.
+          # Only when REAL_E2E_TURNSTILE_TOKEN is supplied does the script switch to full-real.
+          # TURNSTILE_SECRET_KEY is only needed for that optional full-real path.
+          ./scripts/e2e-real-release.sh
+
       - name: Normalize image name
         if: steps.version.outputs.release_required == 'true'
         id: image

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 
 # node_modules
 **/node_modules/**
+.tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: compose-e2e-mock compose-e2e-down e2e-kind-mock e2e-kind-keep e2e-kind-clean e2e-real-local
+
+compose-e2e-mock:
+	cp -n dev/.env.example dev/.env || true
+	chmod +x scripts/e2e-smoke-mock.sh
+	docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml up -d --build
+	./scripts/e2e-smoke-mock.sh "http://127.0.0.1:$$(awk -F= '/^TRAEFIK_PORT=/{print $$2; found=1} END{if(!found) print 8080}' dev/.env)"
+
+compose-e2e-down:
+	docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml down -v
+
+e2e-kind-mock:
+	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh
+	./scripts/helm-e2e-kind.sh
+
+e2e-kind-keep:
+	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh
+	KEEP_CLUSTER=true ./scripts/helm-e2e-kind.sh
+
+e2e-kind-clean:
+	kind delete cluster --name turnstile-appcheck-gateway-e2e || true
+	rm -f .tmp/kind-turnstile-appcheck-gateway-e2e.kubeconfig || true
+
+e2e-real-local:
+	chmod +x scripts/e2e-real-local.sh
+	./scripts/e2e-real-local.sh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   - [設定](#設定)
   - [管理ダッシュボードと監査ログ](#管理ダッシュボードと監査ログ)
   - [Firebase Web CustomProvider](#firebase-web-customprovider)
-  - [開発起動](#開発起動)
+  - [開発モードで立ち上げ](#開発モードで立ち上げ)
   - [ビルド](#ビルド)
 - [References](#references)
 
@@ -315,17 +315,7 @@ npm run check
 npm run build
 ```
 
-Run tests:
-
-```bash
-go test ./...
-```
-
-When local Go is unavailable:
-
-```bash
-docker run --rm -v "$PWD":/src -w /src golang:1.26.2 sh -lc '/usr/local/go/bin/go test ./...'
-```
+For contributor-focused test, CI, and release notes, see [docs/e2e-and-release.md](docs/e2e-and-release.md).
 
 ### English Build
 
@@ -359,8 +349,6 @@ docker buildx build \
   --push \
   ./
 ```
-
-Release automation runs for Pull Requests merged from `feature/**` into `main`. It computes the next release version from PR title/body and commit messages, creates a `vX.Y.Z` tag, publishes GHCR images, and creates a GitHub Release.
 
 ## 日本語
 
@@ -596,7 +584,7 @@ initializeAppCheck(firebaseApp, {
 <div id="turnstile-widget"></div>
 ```
 
-### 開発起動
+### 開発モードで立ち上げ
 
 Docker で service を起動します。
 
@@ -641,17 +629,7 @@ npm run check
 npm run build
 ```
 
-test:
-
-```bash
-go test ./...
-```
-
-local Go が無い場合:
-
-```bash
-docker run --rm -v "$PWD":/src -w /src golang:1.26.2 sh -lc '/usr/local/go/bin/go test ./...'
-```
+contributor / operator 向けの test、CI、release 運用メモは [docs/e2e-and-release.md](docs/e2e-and-release.md) を参照してください。
 
 ### ビルド
 
@@ -685,8 +663,6 @@ docker buildx build \
   --push \
   ./
 ```
-
-Release automation は `feature/**` から `main` へ merge された Pull Request を契機に実行されます。PR title / body / commit messages から次の release version を計算し、`vX.Y.Z` tag、GHCR image、GitHub Release を作成します。
 
 ## References
 

--- a/cmd/turnstile-appcheck-gateway/main.go
+++ b/cmd/turnstile-appcheck-gateway/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/audit"
 	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/auth"
 	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/config"
+	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/e2e"
 	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/firebaseappcheck"
 	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/handlers"
 	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/health"
@@ -63,54 +64,69 @@ func run() error {
 		})
 	}
 
-	normalizedCredsJSON, serviceAccount, err := auth.NormalizeJSON(cfg.ServiceAccountJSON)
-	if err != nil {
-		return fmt.Errorf("normalize service account json: %w", err)
-	}
-	privateKey, err := auth.ParseRSAPrivateKey(serviceAccount)
-	if err != nil {
-		return fmt.Errorf("parse service account key: %w", err)
-	}
-
 	ctx := context.Background()
-	tokenSource, err := auth.NewTokenSource(ctx, normalizedCredsJSON,
-		"https://www.googleapis.com/auth/firebase",
-		"https://www.googleapis.com/auth/cloud-platform",
-	)
-	if err != nil {
-		return fmt.Errorf("create oauth token source: %w", err)
-	}
-
 	outboundHTTPClient := &http.Client{Timeout: cfg.RequestTimeout}
-	turnstileClient, err := turnstile.NewClient(outboundHTTPClient, cfg.TurnstileSecretKey, cfg.TurnstileSiteVerifyURL)
-	if err != nil {
-		return fmt.Errorf("create turnstile client: %w", err)
-	}
+	var turnstileVerifier turnstile.Verifier
+	var appCheckExchanger firebaseappcheck.Exchanger
+	var appCheckVerifier handlers.VerifyTokenVerifier
 
-	appCheckExchangeClient, err := firebaseappcheck.NewClient(
-		outboundHTTPClient,
-		tokenSource,
-		privateKey,
-		serviceAccount.ClientEmail,
-		cfg.FirebaseAppResource,
-		cfg.FirebaseAppID,
-		firebaseappcheck.CustomTokenOptions{
-			TTLMillis: ptrInt64(cfg.AppCheckTokenTTL.Milliseconds()),
-		},
-		logger,
-	)
-	if err != nil {
-		return fmt.Errorf("create firebase appcheck exchanger: %w", err)
-	}
+	if cfg.IsMockUpstreamMode() {
+		logger.Info("starting with mock upstream mode", "mode", cfg.E2E.UpstreamMode)
+		turnstileVerifier = e2e.NewMockTurnstileVerifier(cfg.E2E)
+		appCheckExchanger = e2e.NewMockAppCheckExchanger(cfg.E2E, cfg.AppCheckTokenTTL)
+		appCheckVerifier = e2e.NewMockVerifyTokenVerifier(cfg.E2E)
+	} else {
+		normalizedCredsJSON, serviceAccount, err := auth.NormalizeJSON(cfg.ServiceAccountJSON)
+		if err != nil {
+			return fmt.Errorf("normalize service account json: %w", err)
+		}
+		privateKey, err := auth.ParseRSAPrivateKey(serviceAccount)
+		if err != nil {
+			return fmt.Errorf("parse service account key: %w", err)
+		}
 
-	adminApp, err := firebase.NewApp(ctx, &firebase.Config{ProjectID: cfg.FirebaseProjectID}, option.WithCredentialsJSON(normalizedCredsJSON))
-	if err != nil {
-		return fmt.Errorf("initialize firebase admin app: %w", err)
-	}
+		tokenSource, err := auth.NewTokenSource(ctx, normalizedCredsJSON,
+			"https://www.googleapis.com/auth/firebase",
+			"https://www.googleapis.com/auth/cloud-platform",
+		)
+		if err != nil {
+			return fmt.Errorf("create oauth token source: %w", err)
+		}
 
-	appCheckVerifier, err := adminApp.AppCheck(ctx)
-	if err != nil {
-		return fmt.Errorf("initialize firebase app check verifier: %w", err)
+		turnstileClient, err := turnstile.NewClient(outboundHTTPClient, cfg.TurnstileSecretKey, cfg.TurnstileSiteVerifyURL)
+		if err != nil {
+			return fmt.Errorf("create turnstile client: %w", err)
+		}
+
+		appCheckExchangeClient, err := firebaseappcheck.NewClient(
+			outboundHTTPClient,
+			tokenSource,
+			privateKey,
+			serviceAccount.ClientEmail,
+			cfg.FirebaseAppResource,
+			cfg.FirebaseAppID,
+			firebaseappcheck.CustomTokenOptions{
+				TTLMillis: ptrInt64(cfg.AppCheckTokenTTL.Milliseconds()),
+			},
+			logger,
+		)
+		if err != nil {
+			return fmt.Errorf("create firebase appcheck exchanger: %w", err)
+		}
+
+		adminApp, err := firebase.NewApp(ctx, &firebase.Config{ProjectID: cfg.FirebaseProjectID}, option.WithCredentialsJSON(normalizedCredsJSON))
+		if err != nil {
+			return fmt.Errorf("initialize firebase admin app: %w", err)
+		}
+
+		adminVerifier, err := adminApp.AppCheck(ctx)
+		if err != nil {
+			return fmt.Errorf("initialize firebase app check verifier: %w", err)
+		}
+
+		turnstileVerifier = turnstileClient
+		appCheckExchanger = appCheckExchangeClient
+		appCheckVerifier = adminVerifier
 	}
 
 	exchangeHandler := &handlers.ExchangeHandler{
@@ -118,8 +134,8 @@ func run() error {
 		Timeout: func(parent context.Context) (context.Context, context.CancelFunc) {
 			return context.WithTimeout(parent, cfg.RequestTimeout)
 		},
-		TurnstileVerifier: turnstileClient,
-		Exchanger:         appCheckExchangeClient,
+		TurnstileVerifier: turnstileVerifier,
+		Exchanger:         appCheckExchanger,
 		TrustProxyHeaders: cfg.TrustProxyHeaders,
 		OriginAllowed:     cfg.IsExchangeOriginAllowed,
 		Audit:             auditRecorder,

--- a/dev/docker-compose.e2e.yml
+++ b/dev/docker-compose.e2e.yml
@@ -1,0 +1,25 @@
+services:
+  turnstile-appcheck-gateway:
+    environment:
+      E2E_UPSTREAM_MODE: mock
+      E2E_TURNSTILE_PASS_TOKEN: e2e-turnstile-pass
+      E2E_TURNSTILE_FAIL_TOKEN: e2e-turnstile-fail
+      E2E_APPCHECK_TOKEN: e2e-appcheck-valid-token
+      E2E_APPCHECK_APP_ID: e2e-app-id
+      ADMIN_AUTH_MODE: header
+      ADMIN_ALLOWED_GROUPS: gateway-admins
+      AUDIT_SQLITE_PATH: /var/lib/turnstile-appcheck-gateway/audit.db
+      RATE_LIMIT_ENABLED: "false"
+    labels:
+      - traefik.group=appcheck-dev
+      - traefik.enable=true
+      - traefik.http.routers.appcheck.rule=PathPrefix(`/appcheck`)
+      - traefik.http.routers.appcheck.entrypoints=web
+      - traefik.http.routers.appcheck.priority=100
+      - traefik.http.services.appcheck.loadbalancer.server.port=8080
+      - traefik.http.routers.appcheck-healthz.rule=Path(`/healthz`)
+      - traefik.http.routers.appcheck-healthz.entrypoints=web
+      - traefik.http.routers.appcheck-healthz.priority=110
+      - traefik.http.routers.appcheck-readyz.rule=Path(`/readyz`)
+      - traefik.http.routers.appcheck-readyz.entrypoints=web
+      - traefik.http.routers.appcheck-readyz.priority=110

--- a/dev/frontend/index.html
+++ b/dev/frontend/index.html
@@ -129,6 +129,18 @@
 
         <label for="turnstileToken">Turnstile token</label>
         <textarea id="turnstileToken" placeholder="Turnstileウィジェットで得たtokenを貼り付け"></textarea>
+        <label for="realE2ESnippet">Local real e2e continuation snippet</label>
+        <textarea
+          id="realE2ESnippet"
+          readonly
+          placeholder="token取得後に、repo rootで再開用snippetを実行できます"
+        ></textarea>
+        <div class="row">
+          <button class="secondary" id="copyRealE2ESnippetBtn" type="button">snippetをコピー</button>
+        </div>
+        <div class="hint">
+          `scripts/e2e-real-local.sh` が manual full-real 準備 mode で起動された場合、この snippet で e2e を継続できます。
+        </div>
 
         <label>
           <input id="limitedUse" type="checkbox" />
@@ -172,11 +184,53 @@
       const widgetContainer = document.getElementById("turnstileWidget");
       const turnstileStatus = document.getElementById("turnstileStatus");
       const appCheckExpiry = document.getElementById("appCheckExpiry");
+      const realE2ESnippet = document.getElementById("realE2ESnippet");
       const TURNSTILE_SITE_KEY_STORAGE = "turnstile-site-key";
       const rawInjectedSiteKey = "__TURNSTILE_SITE_KEY__";
       const injectedSiteKey =
         rawInjectedSiteKey === "__TURNSTILE_SITE_KEY__" ? "" : rawInjectedSiteKey.trim();
       let widgetId = null;
+      const params = new URLSearchParams(window.location.search);
+
+      function shellEscapeSingleQuote(value) {
+        return String(value || "").replace(/'/g, "'\"'\"'");
+      }
+
+      function renderRealE2ESnippet(token) {
+        const stateDir = (params.get("e2e_state_dir") || "").trim();
+        const envFile = (params.get("e2e_env_file") || "").trim();
+        if (!token || !stateDir) {
+          realE2ESnippet.value = "";
+          return;
+        }
+        const parts = [
+          `ENV_FILE='${shellEscapeSingleQuote(envFile)}'`,
+          `REAL_E2E_LOCAL_STATE_DIR='${shellEscapeSingleQuote(stateDir)}'`,
+          `REAL_E2E_TURNSTILE_TOKEN='${shellEscapeSingleQuote(token)}'`,
+          "./scripts/e2e-real-local.sh --continue"
+        ];
+        realE2ESnippet.value = parts.join(" ");
+      }
+
+      async function copyText(textarea) {
+        const value = textarea.value;
+        if (!value) {
+          throw new Error("copy source is empty");
+        }
+
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(value);
+          return;
+        }
+
+        textarea.focus();
+        textarea.select();
+        textarea.setSelectionRange(0, value.length);
+        const ok = document.execCommand("copy");
+        if (!ok) {
+          throw new Error("clipboard copy fallback failed");
+        }
+      }
 
       function setOutput(label, payload) {
         output.textContent = `[${new Date().toISOString()}] ${label}\n${
@@ -191,12 +245,14 @@
       function getTurnstileToken() {
         const manual = turnstileTokenInput.value.trim();
         if (manual) {
+          renderRealE2ESnippet(manual);
           return manual;
         }
         if (window.turnstile && widgetId !== null) {
           const tokenFromWidget = window.turnstile.getResponse(widgetId) || "";
           if (tokenFromWidget) {
             turnstileTokenInput.value = tokenFromWidget;
+            renderRealE2ESnippet(tokenFromWidget);
             return tokenFromWidget;
           }
         }
@@ -233,19 +289,23 @@
         }
         widgetContainer.innerHTML = "";
         turnstileTokenInput.value = "";
+        renderRealE2ESnippet("");
 
         widgetId = window.turnstile.render(widgetContainer, {
           sitekey: siteKey,
           callback: (token) => {
             turnstileTokenInput.value = token;
+            renderRealE2ESnippet(token);
             setTurnstileStatus("Turnstile token を取得しました。");
           },
           "expired-callback": () => {
             turnstileTokenInput.value = "";
+            renderRealE2ESnippet("");
             setTurnstileStatus("Turnstile token が期限切れです。再度認証してください。");
           },
           "error-callback": () => {
             turnstileTokenInput.value = "";
+            renderRealE2ESnippet("");
             setTurnstileStatus("Turnstile の検証でエラーが発生しました。");
           }
         });
@@ -258,6 +318,7 @@
           window.turnstile.reset(widgetId);
         }
         turnstileTokenInput.value = "";
+        renderRealE2ESnippet("");
         setTurnstileStatus("Turnstile をリセットしました。");
       }
 
@@ -388,6 +449,24 @@
         appCheckExpiry.textContent = "有効期限: 未取得";
       });
 
+      turnstileTokenInput.addEventListener("input", () => {
+        renderRealE2ESnippet(turnstileTokenInput.value.trim());
+      });
+
+      document.getElementById("copyRealE2ESnippetBtn").addEventListener("click", async () => {
+        const snippet = realE2ESnippet.value.trim();
+        if (!snippet) {
+          setOutput("snippet", "continuation snippet はまだ生成されていません。");
+          return;
+        }
+        try {
+          await copyText(realE2ESnippet);
+          setOutput("snippet", "continuation snippet を clipboard にコピーしました。");
+        } catch (err) {
+          setOutput("snippet-copy-error", String(err));
+        }
+      });
+
       document.getElementById("renderWidgetBtn").addEventListener("click", async () => {
         try {
           await renderTurnstileWidget();
@@ -401,7 +480,6 @@
       });
 
       (function initSiteKey() {
-        const params = new URLSearchParams(window.location.search);
         const fromQuery = (params.get("sitekey") || "").trim();
         const fromStorage = (localStorage.getItem(TURNSTILE_SITE_KEY_STORAGE) || "").trim();
         const initial = fromQuery || fromStorage || injectedSiteKey;
@@ -411,6 +489,7 @@
             setTurnstileStatus(`初期描画失敗: ${String(err)}`);
           });
         }
+        renderRealE2ESnippet(turnstileTokenInput.value.trim());
       })();
     </script>
   </body>

--- a/docs/e2e-and-release.md
+++ b/docs/e2e-and-release.md
@@ -1,0 +1,195 @@
+# E2E, CI, and Release Notes
+
+## English
+
+This document is for contributors and operators who need to run e2e tests, validate the Helm chart, or understand release automation. 
+
+### PR mock e2e
+
+Pull Request CI uses mock mode. It does not contact real Cloudflare Turnstile or Firebase App Check.
+
+Commands:
+
+```bash
+make compose-e2e-mock
+make compose-e2e-down
+make e2e-kind-mock
+```
+
+`compose-e2e-mock` uses the Compose override in `dev/docker-compose.e2e.yml`.
+
+`e2e-kind-mock` uses a repository-local kubeconfig under `.tmp/` and never targets `~/.kube/config`.
+
+Keep the kind cluster:
+
+```bash
+KEEP_CLUSTER=true make e2e-kind-mock
+```
+
+Cleanup:
+
+```bash
+make e2e-kind-clean
+```
+
+### Local real e2e
+
+Local real e2e has two modes.
+
+- `full-real`: real Turnstile + real Firebase
+- `half-real`: dummy Turnstile + real Firebase
+
+Direct full-real:
+
+```bash
+REAL_E2E_TURNSTILE_TOKEN='...' make e2e-real-local
+```
+
+Manual full-real preparation:
+
+```bash
+make e2e-real-local
+```
+
+This starts the local stack and prints a `localhost` frontend URL. Open that page, obtain a Turnstile token, then run the continuation snippet shown in the page.
+
+Force the dummy fallback:
+
+```bash
+LOCAL_E2E_FORCE_HALF_REAL=true make e2e-real-local
+```
+
+Mode is printed explicitly in the logs.
+
+- `turnstile mode: full-real (REAL_E2E_TURNSTILE_TOKEN)`
+- `turnstile mode: half-real (dummy-turnstile-real-firebase)`
+
+### Release e2e
+
+The release workflow runs integration e2e before tag creation, image push, Helm chart push, and GitHub Release creation.
+
+Release modes:
+
+- `full-real`: only when `REAL_E2E_TURNSTILE_TOKEN` is supplied
+- `half-real`: default path, using dummy Turnstile + real Firebase
+
+Required GitHub Secrets:
+
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_APP_ID`
+- `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`
+
+Optional GitHub Secrets:
+
+- `FIREBASE_APP_RESOURCE`
+- `TURNSTILE_SECRET_KEY`
+- `REAL_E2E_TURNSTILE_TOKEN`
+
+The default release path is half-real, so Turnstile secrets are not required unless the optional full-real path is enabled.
+
+### Relevant files
+
+- `.github/workflows/compose-e2e.yml`
+- `.github/workflows/helm-e2e.yml`
+- `.github/workflows/release.yml`
+- `scripts/e2e-smoke-mock.sh`
+- `scripts/helm-e2e-kind.sh`
+- `scripts/e2e-real-local.sh`
+- `scripts/e2e-real-release.sh`
+
+## 日本語
+
+このドキュメントは、e2e test、Helm chart 検証、release automation を扱う contributor / operator 向けです。
+
+### PR 用 mock e2e
+
+Pull Request CI は mock mode を使います。real Cloudflare Turnstile / Firebase App Check には接続しません。
+
+実行コマンド:
+
+```bash
+make compose-e2e-mock
+make compose-e2e-down
+make e2e-kind-mock
+```
+
+`compose-e2e-mock` は `dev/docker-compose.e2e.yml` を使います。
+
+`e2e-kind-mock` は `.tmp/` 配下の repo-local kubeconfig を使い、`~/.kube/config` は使いません。
+
+kind cluster を残す:
+
+```bash
+KEEP_CLUSTER=true make e2e-kind-mock
+```
+
+cleanup:
+
+```bash
+make e2e-kind-clean
+```
+
+### local real e2e
+
+local real e2e には 2 つの mode があります。
+
+- `full-real`: real Turnstile + real Firebase
+- `half-real`: dummy Turnstile + real Firebase
+
+direct full-real:
+
+```bash
+REAL_E2E_TURNSTILE_TOKEN='...' make e2e-real-local
+```
+
+manual full-real 準備:
+
+```bash
+make e2e-real-local
+```
+
+この実行で local stack が起動し、`localhost` の frontend URL が表示されます。そのページで Turnstile token を取得し、画面に表示される continuation snippet を repo root で実行してください。
+
+dummy fallback を明示する:
+
+```bash
+LOCAL_E2E_FORCE_HALF_REAL=true make e2e-real-local
+```
+
+mode は log に明示されます。
+
+- `turnstile mode: full-real (REAL_E2E_TURNSTILE_TOKEN)`
+- `turnstile mode: half-real (dummy-turnstile-real-firebase)`
+
+### release e2e
+
+release workflow は tag 作成、image push、Helm chart push、GitHub Release 作成の前に integration e2e を実行します。
+
+release mode:
+
+- `full-real`: `REAL_E2E_TURNSTILE_TOKEN` がある場合のみ
+- `half-real`: 既定。dummy Turnstile + real Firebase
+
+必須 GitHub Secrets:
+
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_APP_ID`
+- `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`
+
+任意 GitHub Secrets:
+
+- `FIREBASE_APP_RESOURCE`
+- `TURNSTILE_SECRET_KEY`
+- `REAL_E2E_TURNSTILE_TOKEN`
+
+既定 path は half-real なので、optional な full-real を使わない限り Turnstile secret は不要です。
+
+### 関連ファイル
+
+- `.github/workflows/compose-e2e.yml`
+- `.github/workflows/helm-e2e.yml`
+- `.github/workflows/release.yml`
+- `scripts/e2e-smoke-mock.sh`
+- `scripts/helm-e2e-kind.sh`
+- `scripts/e2e-real-local.sh`
+- `scripts/e2e-real-release.sh`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,10 @@ const (
 	defaultAuditRetentionDays = 90
 	defaultRateLimitRequests  = 120
 	defaultRateLimitWindow    = time.Minute
+	defaultE2ETurnstilePass   = "e2e-turnstile-pass"
+	defaultE2ETurnstileFail   = "e2e-turnstile-fail"
+	defaultE2EAppCheckToken   = "e2e-appcheck-valid-token"
+	defaultE2EAppCheckAppID   = "e2e-app-id"
 )
 
 // Config is the runtime configuration built from environment variables.
@@ -63,9 +67,18 @@ type Config struct {
 	HealthPath string
 	ReadyPath  string
 
+	E2E       E2EConfig
 	Admin     AdminConfig
 	Audit     AuditConfig
 	RateLimit RateLimitConfig
+}
+
+type E2EConfig struct {
+	UpstreamMode       string
+	TurnstilePassToken string
+	TurnstileFailToken string
+	AppCheckToken      string
+	AppCheckAppID      string
 }
 
 type AdminConfig struct {
@@ -128,6 +141,13 @@ func loadFromMap(env map[string]string) (*Config, error) {
 		VerifyFailureStatus:    defaultVerifyFailure,
 		HealthPath:             normalizeHealthPath(getOrDefault(env, "HEALTH_PATH", defaultHealthPath)),
 		ReadyPath:              normalizeHealthPath(getOrDefault(env, "READY_PATH", defaultReadyPath)),
+		E2E: E2EConfig{
+			UpstreamMode:       strings.ToLower(strings.TrimSpace(env["E2E_UPSTREAM_MODE"])),
+			TurnstilePassToken: strings.TrimSpace(getOrDefault(env, "E2E_TURNSTILE_PASS_TOKEN", defaultE2ETurnstilePass)),
+			TurnstileFailToken: strings.TrimSpace(getOrDefault(env, "E2E_TURNSTILE_FAIL_TOKEN", defaultE2ETurnstileFail)),
+			AppCheckToken:      strings.TrimSpace(getOrDefault(env, "E2E_APPCHECK_TOKEN", defaultE2EAppCheckToken)),
+			AppCheckAppID:      strings.TrimSpace(getOrDefault(env, "E2E_APPCHECK_APP_ID", defaultE2EAppCheckAppID)),
+		},
 		Admin: AdminConfig{
 			Dashboard: AdminDashboardConfig{
 				Enabled:           true,
@@ -157,32 +177,56 @@ func loadFromMap(env map[string]string) (*Config, error) {
 		},
 	}
 
-	var missing []string
-
-	cfg.TurnstileSecretKey = strings.TrimSpace(env["TURNSTILE_SECRET_KEY"])
-	if cfg.TurnstileSecretKey == "" {
-		missing = append(missing, "TURNSTILE_SECRET_KEY")
+	switch cfg.E2E.UpstreamMode {
+	case "", "mock":
+	default:
+		return nil, fmt.Errorf("E2E_UPSTREAM_MODE must be empty or mock")
 	}
+	if cfg.IsMockUpstreamMode() {
+		if cfg.E2E.TurnstilePassToken == "" {
+			return nil, fmt.Errorf("E2E_TURNSTILE_PASS_TOKEN is required when E2E_UPSTREAM_MODE=mock")
+		}
+		if cfg.E2E.TurnstileFailToken == "" {
+			return nil, fmt.Errorf("E2E_TURNSTILE_FAIL_TOKEN is required when E2E_UPSTREAM_MODE=mock")
+		}
+		if cfg.E2E.TurnstilePassToken == cfg.E2E.TurnstileFailToken {
+			return nil, fmt.Errorf("E2E_TURNSTILE_PASS_TOKEN and E2E_TURNSTILE_FAIL_TOKEN must differ")
+		}
+		if cfg.E2E.AppCheckToken == "" {
+			return nil, fmt.Errorf("E2E_APPCHECK_TOKEN is required when E2E_UPSTREAM_MODE=mock")
+		}
+		if cfg.E2E.AppCheckAppID == "" {
+			return nil, fmt.Errorf("E2E_APPCHECK_APP_ID is required when E2E_UPSTREAM_MODE=mock")
+		}
+	}
+
+	var missing []string
 
 	cfg.FirebaseProjectID = strings.TrimSpace(env["FIREBASE_PROJECT_ID"])
 	cfg.FirebaseAppID = strings.TrimSpace(env["FIREBASE_APP_ID"])
 	cfg.FirebaseAppResource = strings.TrimSpace(env["FIREBASE_APP_RESOURCE"])
-
-	if cfg.FirebaseProjectID == "" {
-		missing = append(missing, "FIREBASE_PROJECT_ID")
-	}
-	if cfg.FirebaseAppResource == "" && cfg.FirebaseAppID == "" {
-		missing = append(missing, "FIREBASE_APP_ID (required when FIREBASE_APP_RESOURCE is not set)")
-	}
-
 	var err error
-	cfg.ServiceAccountJSON, err = readServiceAccountJSON(env)
-	if err != nil {
-		missing = append(missing, err.Error())
-	}
+	if !cfg.IsMockUpstreamMode() {
+		cfg.TurnstileSecretKey = strings.TrimSpace(env["TURNSTILE_SECRET_KEY"])
+		if cfg.TurnstileSecretKey == "" {
+			missing = append(missing, "TURNSTILE_SECRET_KEY")
+		}
 
-	if cfg.FirebaseAppResource == "" && cfg.FirebaseProjectID != "" && cfg.FirebaseAppID != "" {
-		cfg.FirebaseAppResource = fmt.Sprintf("projects/%s/apps/%s", cfg.FirebaseProjectID, cfg.FirebaseAppID)
+		if cfg.FirebaseProjectID == "" {
+			missing = append(missing, "FIREBASE_PROJECT_ID")
+		}
+		if cfg.FirebaseAppResource == "" && cfg.FirebaseAppID == "" {
+			missing = append(missing, "FIREBASE_APP_ID (required when FIREBASE_APP_RESOURCE is not set)")
+		}
+
+		cfg.ServiceAccountJSON, err = readServiceAccountJSON(env)
+		if err != nil {
+			missing = append(missing, err.Error())
+		}
+
+		if cfg.FirebaseAppResource == "" && cfg.FirebaseProjectID != "" && cfg.FirebaseAppID != "" {
+			cfg.FirebaseAppResource = fmt.Sprintf("projects/%s/apps/%s", cfg.FirebaseProjectID, cfg.FirebaseAppID)
+		}
 	}
 
 	if timeoutRaw := strings.TrimSpace(env["REQUEST_TIMEOUT"]); timeoutRaw != "" {
@@ -303,14 +347,20 @@ func loadFromMap(env map[string]string) (*Config, error) {
 		return nil, errors.New("missing/invalid required configuration: " + strings.Join(missing, ", "))
 	}
 
-	if !isValidAppResource(cfg.FirebaseAppResource) {
-		return nil, fmt.Errorf("invalid FIREBASE_APP_RESOURCE: %q", cfg.FirebaseAppResource)
-	}
-	if cfg.FirebaseAppID == "" {
-		cfg.FirebaseAppID = appIDFromResource(cfg.FirebaseAppResource)
+	if !cfg.IsMockUpstreamMode() {
+		if !isValidAppResource(cfg.FirebaseAppResource) {
+			return nil, fmt.Errorf("invalid FIREBASE_APP_RESOURCE: %q", cfg.FirebaseAppResource)
+		}
+		if cfg.FirebaseAppID == "" {
+			cfg.FirebaseAppID = appIDFromResource(cfg.FirebaseAppResource)
+		}
 	}
 
 	return cfg, nil
+}
+
+func (c *Config) IsMockUpstreamMode() bool {
+	return c != nil && c.E2E.UpstreamMode == "mock"
 }
 
 // IsExchangeOriginAllowed returns whether origin is allowed. Empty allow-list means allow all.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,6 +173,33 @@ func TestLoadFromMapMissingRequired(t *testing.T) {
 	}
 }
 
+func TestLoadFromMapMockModeSkipsRealUpstreamRequirements(t *testing.T) {
+	cfg, err := loadFromMap(map[string]string{
+		"E2E_UPSTREAM_MODE": "mock",
+	})
+	if err != nil {
+		t.Fatalf("loadFromMap() error = %v", err)
+	}
+	if !cfg.IsMockUpstreamMode() {
+		t.Fatal("expected mock upstream mode to be enabled")
+	}
+	if cfg.E2E.TurnstilePassToken != "e2e-turnstile-pass" {
+		t.Fatalf("TurnstilePassToken = %q", cfg.E2E.TurnstilePassToken)
+	}
+	if cfg.E2E.AppCheckToken != "e2e-appcheck-valid-token" {
+		t.Fatalf("AppCheckToken = %q", cfg.E2E.AppCheckToken)
+	}
+}
+
+func TestLoadFromMapRejectsInvalidMockMode(t *testing.T) {
+	_, err := loadFromMap(map[string]string{
+		"E2E_UPSTREAM_MODE": "real",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid E2E_UPSTREAM_MODE")
+	}
+}
+
 func TestIsExchangeOriginAllowed(t *testing.T) {
 	env := minimalEnv()
 	env["ALLOWED_EXCHANGE_ORIGINS"] = "https://example.com,https://www.example.com"

--- a/internal/e2e/mock.go
+++ b/internal/e2e/mock.go
@@ -1,0 +1,86 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	firebaseappchecksdk "firebase.google.com/go/v4/appcheck"
+
+	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/config"
+	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/firebaseappcheck"
+	"github.com/michibiki-io/turnstile-appcheck-gateway/internal/turnstile"
+)
+
+var errMockAppCheckTokenInvalid = errors.New("mock app check token is invalid")
+
+type MockTurnstileVerifier struct {
+	passToken string
+	failToken string
+}
+
+func NewMockTurnstileVerifier(cfg config.E2EConfig) *MockTurnstileVerifier {
+	return &MockTurnstileVerifier{
+		passToken: cfg.TurnstilePassToken,
+		failToken: cfg.TurnstileFailToken,
+	}
+}
+
+func (v *MockTurnstileVerifier) Verify(_ context.Context, req turnstile.VerifyRequest) (*turnstile.VerifyResponse, error) {
+	if req.Token == v.passToken {
+		return &turnstile.VerifyResponse{Success: true}, nil
+	}
+	errorCodes := []string{"invalid-input-response"}
+	if req.Token == v.failToken {
+		errorCodes = []string{"timeout-or-duplicate"}
+	}
+	return &turnstile.VerifyResponse{
+		Success:    false,
+		ErrorCodes: errorCodes,
+	}, nil
+}
+
+type MockAppCheckExchanger struct {
+	token string
+	ttl   time.Duration
+	now   func() time.Time
+}
+
+func NewMockAppCheckExchanger(cfg config.E2EConfig, ttl time.Duration) *MockAppCheckExchanger {
+	if ttl <= 0 {
+		ttl = 30 * time.Minute
+	}
+	return &MockAppCheckExchanger{
+		token: cfg.AppCheckToken,
+		ttl:   ttl,
+		now:   time.Now,
+	}
+}
+
+func (e *MockAppCheckExchanger) Exchange(_ context.Context, _ bool) (*firebaseappcheck.ExchangeResult, error) {
+	expireAt := e.now().Add(e.ttl).UnixMilli()
+	return &firebaseappcheck.ExchangeResult{
+		Token:            e.token,
+		ExpireTimeMillis: expireAt,
+		TTLMillis:        e.ttl.Milliseconds(),
+	}, nil
+}
+
+type MockVerifyTokenVerifier struct {
+	token string
+	appID string
+}
+
+func NewMockVerifyTokenVerifier(cfg config.E2EConfig) *MockVerifyTokenVerifier {
+	return &MockVerifyTokenVerifier{
+		token: cfg.AppCheckToken,
+		appID: cfg.AppCheckAppID,
+	}
+}
+
+func (v *MockVerifyTokenVerifier) VerifyToken(token string) (*firebaseappchecksdk.DecodedAppCheckToken, error) {
+	if token != v.token {
+		return nil, errMockAppCheckTokenInvalid
+	}
+	return &firebaseappchecksdk.DecodedAppCheckToken{AppID: v.appID}, nil
+}

--- a/internal/handlers/exchange_test.go
+++ b/internal/handlers/exchange_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +99,51 @@ func TestExchangeHandlerTurnstileFailure(t *testing.T) {
 	r.POST("/exchange", h.Handle)
 
 	req := httptest.NewRequest(http.MethodPost, "/exchange", bytes.NewBufferString(`{"turnstileToken":"token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExchangeHandlerRejectsUnknownField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: exchangeTurnstileStub{resp: &turnstile.VerifyResponse{Success: true}},
+		Exchanger:         exchangeStub{result: &firebaseappcheck.ExchangeResult{Token: "appcheck-token", ExpireTimeMillis: 1000}},
+	}
+
+	r := gin.New()
+	r.POST("/exchange", h.Handle)
+
+	req := httptest.NewRequest(http.MethodPost, "/exchange", bytes.NewBufferString(`{"turnstileToken":"token","unexpected":"attack"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExchangeHandlerRejectsOversizedToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: exchangeTurnstileStub{resp: &turnstile.VerifyResponse{Success: true}},
+		Exchanger:         exchangeStub{result: &firebaseappcheck.ExchangeResult{Token: "appcheck-token", ExpireTimeMillis: 1000}},
+	}
+
+	r := gin.New()
+	r.POST("/exchange", h.Handle)
+
+	payload := `{"turnstileToken":"` + strings.Repeat("a", 4097) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/exchange", bytes.NewBufferString(payload))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/scripts/e2e-real-local.sh
+++ b/scripts/e2e-real-local.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-}"
+WORK_DIR=""
+PRESERVE_WORK_DIR="false"
+HTTP_STATUS=""
+
+TURNSTILE_TEST_SITE_KEY="1x00000000000000000000AA"
+TURNSTILE_TEST_SECRET_KEY="1x0000000000000000000000000000000AA"
+TURNSTILE_TEST_TOKEN="XXXX.DUMMY.TOKEN.XXXX"
+
+TURNSTILE_MODE=""
+TURNSTILE_MODE_DETAIL=""
+TURNSTILE_SITE_KEY_EFFECTIVE=""
+TURNSTILE_SECRET_KEY_EFFECTIVE=""
+TURNSTILE_TOKEN="${REAL_E2E_TURNSTILE_TOKEN:-}"
+VERIFY_SUCCESS_STATUS=""
+BASE_URL=""
+STATE_DIR="${REAL_E2E_LOCAL_STATE_DIR:-}"
+CONTINUE_MODE="false"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/e2e-real-local.sh
+  REAL_E2E_TURNSTILE_TOKEN=... scripts/e2e-real-local.sh --continue
+
+Modes:
+  - full-real:
+      REAL_E2E_TURNSTILE_TOKEN を使って real Turnstile + real Firebase を検証する
+  - half-real:
+      dummy Turnstile + real Firebase を検証する
+
+Interactive local flow:
+  1. scripts/e2e-real-local.sh を実行
+  2. frontend で token を取得
+  3. frontend に表示された snippet を repo root で実行
+EOF
+}
+
+cleanup() {
+  if [[ "${PRESERVE_WORK_DIR}" != "true" && -n "${WORK_DIR}" ]]; then
+    docker compose --env-file "${ENV_FILE}" -f "${ROOT_DIR}/dev/docker-compose.yml" -f "${WORK_DIR}/override.yml" down -v >/dev/null 2>&1 || true
+  fi
+  if [[ "${PRESERVE_WORK_DIR}" != "true" && -n "${WORK_DIR}" ]]; then
+    rm -rf "${WORK_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+env_file_value() {
+  python3 - "$1" "$2" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+key = sys.argv[2]
+for raw in path.read_text(encoding="utf-8").splitlines():
+    line = raw.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    current_key, value = line.split("=", 1)
+    if current_key.strip() == key:
+        print(value.strip())
+        break
+PY
+}
+
+env_value() {
+  local key="$1"
+  local current="${!key:-}"
+  if [[ -n "${current}" ]]; then
+    printf '%s' "${current}"
+    return
+  fi
+  env_file_value "${ENV_FILE}" "${key}"
+}
+
+resolve_env_file() {
+  if [[ -n "${ENV_FILE}" ]]; then
+    return 0
+  fi
+  if [[ -f "${ROOT_DIR}/dev/.env" ]]; then
+    ENV_FILE="${ROOT_DIR}/dev/.env"
+    return 0
+  fi
+  if [[ -f "${ROOT_DIR}/.env" ]]; then
+    ENV_FILE="${ROOT_DIR}/.env"
+    return 0
+  fi
+  echo "missing env file: set ENV_FILE or create dev/.env or .env" >&2
+  exit 1
+}
+
+require_env_value() {
+  local value="$1"
+  local label="$2"
+  if [[ -z "${value}" ]]; then
+    echo "missing required value: ${label}" >&2
+    exit 1
+  fi
+}
+
+run_curl() {
+  local outfile="$1"
+  local method="$2"
+  local url="$3"
+  shift 3
+  HTTP_STATUS="$(curl -sS -o "${outfile}" -w "%{http_code}" -X "${method}" "${url}" "$@")"
+}
+
+assert_status() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${label}: expected HTTP ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_status_class_4xx() {
+  local actual="$1"
+  local label="$2"
+  if [[ ! "${actual}" =~ ^4[0-9][0-9]$ ]]; then
+    echo "${label}: expected 4xx, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+wait_for_status() {
+  local path="$1"
+  local expected="$2"
+  local label="$3"
+  local outfile="${WORK_DIR}/wait.out"
+  local attempt
+  for attempt in $(seq 1 90); do
+    if run_curl "${outfile}" GET "${BASE_URL}${path}"; then
+      if [[ "${HTTP_STATUS}" == "${expected}" ]]; then
+        echo "${label}: HTTP ${expected}"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "${label}: service did not become ready" >&2
+  exit 1
+}
+
+extract_json_field() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data[sys.argv[2]]
+if isinstance(value, (dict, list)):
+    raise SystemExit(f"field {sys.argv[2]} must be scalar")
+print(value)
+PY
+}
+
+urlencode() {
+  python3 - "$1" <<'PY'
+import sys
+from urllib.parse import quote
+print(quote(sys.argv[1], safe=""))
+PY
+}
+
+shell_escape() {
+  printf '%q' "$1"
+}
+
+is_interactive() {
+  [[ "${CI:-}" != "true" && -t 0 && -t 1 ]]
+}
+
+build_override_file() {
+  cat > "${WORK_DIR}/override.yml" <<EOF
+services:
+  turnstile-appcheck-gateway:
+    environment:
+      TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY_EFFECTIVE}
+      ADMIN_AUTH_MODE: header
+      ADMIN_ALLOWED_GROUPS: gateway-admins
+      AUDIT_SQLITE_PATH: /var/lib/turnstile-appcheck-gateway/audit.db
+      RATE_LIMIT_ENABLED: "false"
+    labels:
+      - "traefik.http.routers.appcheck-health.rule=Path(\`/healthz\`)"
+      - "traefik.http.routers.appcheck-health.entrypoints=web"
+      - "traefik.http.routers.appcheck-health.priority=110"
+      - "traefik.http.routers.appcheck-ready.rule=Path(\`/readyz\`)"
+      - "traefik.http.routers.appcheck-ready.entrypoints=web"
+      - "traefik.http.routers.appcheck-ready.priority=110"
+  frontend:
+    environment:
+      TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY_EFFECTIVE}
+    labels:
+      - "traefik.http.routers.frontend.rule=PathPrefix(\`/\`) && !PathPrefix(\`/appcheck\`) && !PathPrefix(\`/backend\`) && !Path(\`/healthz\`) && !Path(\`/readyz\`)"
+EOF
+}
+
+write_context_file() {
+  cat > "${WORK_DIR}/context.env" <<EOF
+ENV_FILE=$(shell_escape "${ENV_FILE}")
+BASE_URL=$(shell_escape "${BASE_URL}")
+VERIFY_SUCCESS_STATUS=$(shell_escape "${VERIFY_SUCCESS_STATUS}")
+TURNSTILE_MODE=$(shell_escape "${TURNSTILE_MODE}")
+TURNSTILE_MODE_DETAIL=$(shell_escape "${TURNSTILE_MODE_DETAIL}")
+TURNSTILE_SITE_KEY_EFFECTIVE=$(shell_escape "${TURNSTILE_SITE_KEY_EFFECTIVE}")
+TURNSTILE_SECRET_KEY_EFFECTIVE=$(shell_escape "${TURNSTILE_SECRET_KEY_EFFECTIVE}")
+EOF
+}
+
+load_context_file() {
+  require_env_value "${STATE_DIR}" "REAL_E2E_LOCAL_STATE_DIR"
+  if [[ ! -f "${STATE_DIR}/context.env" ]]; then
+    echo "missing local e2e state: ${STATE_DIR}/context.env" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "${STATE_DIR}/context.env"
+  WORK_DIR="${STATE_DIR}"
+}
+
+configure_turnstile_mode() {
+  local real_site_key="$1"
+  local real_secret_key="$2"
+
+  if [[ -n "${REAL_E2E_TURNSTILE_TOKEN:-}" ]]; then
+    require_env_value "${real_secret_key}" "TURNSTILE_SECRET_KEY"
+    TURNSTILE_MODE="full-real"
+    TURNSTILE_MODE_DETAIL="REAL_E2E_TURNSTILE_TOKEN"
+    TURNSTILE_SITE_KEY_EFFECTIVE="${real_site_key}"
+    TURNSTILE_SECRET_KEY_EFFECTIVE="${real_secret_key}"
+    TURNSTILE_TOKEN="${REAL_E2E_TURNSTILE_TOKEN}"
+    return 0
+  fi
+
+  TURNSTILE_MODE="half-real"
+  TURNSTILE_MODE_DETAIL="dummy-turnstile-real-firebase"
+  TURNSTILE_SITE_KEY_EFFECTIVE="${TURNSTILE_TEST_SITE_KEY}"
+  TURNSTILE_SECRET_KEY_EFFECTIVE="${TURNSTILE_TEST_SECRET_KEY}"
+  TURNSTILE_TOKEN="${TURNSTILE_TEST_TOKEN}"
+}
+
+start_stack() {
+  docker compose --env-file "${ENV_FILE}" -f "${ROOT_DIR}/dev/docker-compose.yml" -f "${WORK_DIR}/override.yml" up -d --build
+  wait_for_status "/healthz" "200" "healthz"
+  wait_for_status "/readyz" "200" "readyz"
+}
+
+prepare_manual_full_real() {
+  local real_site_key="$1"
+  local real_secret_key="$2"
+  local encoded_state_dir
+  local encoded_env_file
+
+  TURNSTILE_MODE="full-real"
+  TURNSTILE_MODE_DETAIL="manual-token-snippet"
+  TURNSTILE_SITE_KEY_EFFECTIVE="${real_site_key}"
+  TURNSTILE_SECRET_KEY_EFFECTIVE="${real_secret_key}"
+
+  WORK_DIR="$(mktemp -d "${ROOT_DIR}/.tmp/e2e-real-local.XXXXXX")"
+  mkdir -p "${WORK_DIR}"
+  build_override_file
+  write_context_file
+  start_stack
+
+  encoded_state_dir="$(urlencode "${WORK_DIR}")"
+  encoded_env_file="$(urlencode "${ENV_FILE}")"
+  PRESERVE_WORK_DIR="true"
+
+  cat <<EOF
+local e2e prepared in full-real manual mode
+turnstile mode: full-real (${TURNSTILE_MODE_DETAIL})
+open frontend: ${BASE_URL}/?e2e_state_dir=${encoded_state_dir}&e2e_env_file=${encoded_env_file}
+
+After the widget issues a token, copy the snippet shown in the page and run it from the repo root.
+If you want the fallback path instead, run:
+  LOCAL_E2E_FORCE_HALF_REAL=true make e2e-real-local
+EOF
+}
+
+check_logs_for_secret() {
+  local compose_log="${WORK_DIR}/compose.log"
+  docker compose --env-file "${ENV_FILE}" -f "${ROOT_DIR}/dev/docker-compose.yml" -f "${WORK_DIR}/override.yml" logs --no-color \
+    > "${compose_log}" 2>/dev/null || true
+
+  local marker
+  for marker in \
+    "$(env_value TURNSTILE_SECRET_KEY)" \
+    "$(env_value GOOGLE_SERVICE_ACCOUNT_JSON_BASE64)" \
+    "${TURNSTILE_TOKEN:-}" \
+    "${APP_CHECK_TOKEN:-}"; do
+    if [[ -n "${marker}" ]] && grep -Fq "${marker}" "${compose_log}"; then
+      echo "compose logs leaked a secret or token" >&2
+      exit 1
+    fi
+  done
+}
+
+run_local_e2e_assertions() {
+  echo "turnstile mode: ${TURNSTILE_MODE} (${TURNSTILE_MODE_DETAIL})"
+
+  cat > "${WORK_DIR}/exchange-valid.json" <<JSON
+{"turnstileToken":"${TURNSTILE_TOKEN}","limitedUse":false}
+JSON
+  run_curl "${WORK_DIR}/exchange-valid.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+    -H "Content-Type: application/json" \
+    --data-binary @"${WORK_DIR}/exchange-valid.json"
+  assert_status "200" "${HTTP_STATUS}" "exchange valid"
+  APP_CHECK_TOKEN="$(extract_json_field "${WORK_DIR}/exchange-valid.out" token)"
+  EXPIRE_TIME_MILLIS="$(extract_json_field "${WORK_DIR}/exchange-valid.out" expireTimeMillis)"
+  if [[ -z "${APP_CHECK_TOKEN}" || -z "${EXPIRE_TIME_MILLIS}" ]]; then
+    echo "exchange valid: missing token or expireTimeMillis" >&2
+    exit 1
+  fi
+  echo "exchange valid: HTTP 200"
+
+  run_curl "${WORK_DIR}/verify-valid.out" GET "${BASE_URL}/appcheck/api/v1/verify" \
+    -H "X-Firebase-AppCheck: ${APP_CHECK_TOKEN}"
+  assert_status "${VERIFY_SUCCESS_STATUS}" "${HTTP_STATUS}" "verify valid"
+  echo "verify valid: HTTP ${VERIFY_SUCCESS_STATUS}"
+
+  run_curl "${WORK_DIR}/exchange-missing.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+    -H "Content-Type: application/json" \
+    --data-binary '{"turnstileToken":"","limitedUse":false}'
+  assert_status "400" "${HTTP_STATUS}" "exchange missing token"
+  echo "exchange missing token: HTTP 400"
+
+  if [[ "${TURNSTILE_MODE}" == "full-real" ]]; then
+    run_curl "${WORK_DIR}/exchange-invalid.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+      -H "Content-Type: application/json" \
+      --data-binary '{"turnstileToken":"invalid-token","limitedUse":false}'
+    assert_status_class_4xx "${HTTP_STATUS}" "exchange invalid token"
+    echo "exchange invalid token: HTTP ${HTTP_STATUS}"
+  else
+    echo "exchange invalid token: skipped in half-real mode"
+  fi
+
+  run_curl "${WORK_DIR}/exchange-malformed.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+    -H "Content-Type: application/json" \
+    --data-binary '{"turnstileToken":'
+  assert_status "400" "${HTTP_STATUS}" "exchange malformed json"
+  echo "exchange malformed json: HTTP 400"
+
+  run_curl "${WORK_DIR}/exchange-unknown.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+    -H "Content-Type: application/json" \
+    --data-binary '{"turnstileToken":"invalid-token","limitedUse":false,"unexpected":"attack"}'
+  assert_status "400" "${HTTP_STATUS}" "exchange unknown field"
+  echo "exchange unknown field: HTTP 400"
+
+  run_curl "${WORK_DIR}/exchange-text.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+    -H "Content-Type: text/plain" \
+    --data-binary 'turnstileToken=invalid-token'
+  assert_status "415" "${HTTP_STATUS}" "exchange wrong content type"
+  echo "exchange wrong content type: HTTP 415"
+
+  run_curl "${WORK_DIR}/verify-missing.out" GET "${BASE_URL}/appcheck/api/v1/verify"
+  assert_status "401" "${HTTP_STATUS}" "verify missing token"
+  echo "verify missing token: HTTP 401"
+
+  run_curl "${WORK_DIR}/verify-invalid.out" GET "${BASE_URL}/appcheck/api/v1/verify" \
+    -H "X-Firebase-AppCheck: invalid-token"
+  assert_status "401" "${HTTP_STATUS}" "verify invalid token"
+  echo "verify invalid token: HTTP 401"
+
+  run_curl "${WORK_DIR}/admin-missing.out" GET "${BASE_URL}/appcheck/_admin/api/v1/request-metrics"
+  assert_status "401" "${HTTP_STATUS}" "admin missing auth"
+  echo "admin missing auth: HTTP 401"
+
+  run_curl "${WORK_DIR}/admin-wrong-group.out" GET "${BASE_URL}/appcheck/_admin/api/v1/request-metrics" \
+    -H "X-Forwarded-User: e2e-admin" \
+    -H "X-Forwarded-Email: e2e-admin@example.com" \
+    -H "X-Forwarded-Groups: forbidden-group"
+  assert_status "403" "${HTTP_STATUS}" "admin wrong group"
+  echo "admin wrong group: HTTP 403"
+
+  run_curl "${WORK_DIR}/admin-valid.out" GET "${BASE_URL}/appcheck/_admin/api/v1/request-metrics" \
+    -H "X-Forwarded-User: e2e-admin" \
+    -H "X-Forwarded-Email: e2e-admin@example.com" \
+    -H "X-Forwarded-Groups: gateway-admins"
+  assert_status "200" "${HTTP_STATUS}" "admin valid auth"
+  echo "admin valid auth: HTTP 200"
+
+  check_logs_for_secret
+  echo "log sanitization: OK"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --continue)
+        CONTINUE_MODE="true"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "unknown argument: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+main() {
+  parse_args "$@"
+  resolve_env_file
+
+  if [[ "${CONTINUE_MODE}" == "true" ]]; then
+    require_env_value "${REAL_E2E_TURNSTILE_TOKEN:-}" "REAL_E2E_TURNSTILE_TOKEN"
+    load_context_file
+    TURNSTILE_TOKEN="${REAL_E2E_TURNSTILE_TOKEN}"
+    TURNSTILE_MODE="full-real"
+    TURNSTILE_MODE_DETAIL="REAL_E2E_TURNSTILE_TOKEN"
+    wait_for_status "/healthz" "200" "healthz"
+    wait_for_status "/readyz" "200" "readyz"
+    run_local_e2e_assertions
+    return 0
+  fi
+
+  local real_site_key
+  local real_secret_key
+
+  mkdir -p "${ROOT_DIR}/.tmp"
+
+  real_site_key="$(env_value TURNSTILE_SITE_KEY)"
+  real_secret_key="$(env_value TURNSTILE_SECRET_KEY)"
+  require_env_value "$(env_value FIREBASE_PROJECT_ID)" "FIREBASE_PROJECT_ID"
+  require_env_value "$(env_value FIREBASE_APP_ID)" "FIREBASE_APP_ID"
+  require_env_value "$(env_value GOOGLE_SERVICE_ACCOUNT_JSON_BASE64)" "GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+
+  TRAEFIK_PORT="$(env_value TRAEFIK_PORT)"
+  if [[ -z "${TRAEFIK_PORT}" ]]; then
+    TRAEFIK_PORT="8080"
+  fi
+  BASE_URL="http://localhost:${TRAEFIK_PORT}"
+  VERIFY_SUCCESS_STATUS="$(env_value VERIFY_SUCCESS_STATUS)"
+  if [[ -z "${VERIFY_SUCCESS_STATUS}" ]]; then
+    VERIFY_SUCCESS_STATUS="204"
+  fi
+
+  if [[ -z "${REAL_E2E_TURNSTILE_TOKEN:-}" && "${LOCAL_E2E_FORCE_HALF_REAL:-false}" != "true" ]] && is_interactive; then
+    require_env_value "${real_site_key}" "TURNSTILE_SITE_KEY"
+    require_env_value "${real_secret_key}" "TURNSTILE_SECRET_KEY"
+    prepare_manual_full_real "${real_site_key}" "${real_secret_key}"
+    return 0
+  fi
+
+  if [[ -z "${REAL_E2E_TURNSTILE_TOKEN:-}" && "${LOCAL_E2E_FORCE_HALF_REAL:-false}" != "true" && "${CI:-}" != "true" ]]; then
+    echo "interactive terminal not detected; using half-real fallback" >&2
+  fi
+
+  configure_turnstile_mode "${real_site_key}" "${real_secret_key}"
+  WORK_DIR="$(mktemp -d "${ROOT_DIR}/.tmp/e2e-real-local-run.XXXXXX")"
+  build_override_file
+  start_stack
+  run_local_e2e_assertions
+}
+
+main "$@"

--- a/scripts/e2e-real-release.sh
+++ b/scripts/e2e-real-release.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+ENV_FILE="${TMP_DIR}/release.env"
+HTTP_STATUS=""
+export TRAEFIK_PORT=8080
+export TRAEFIK_DASHBOARD_PORT=8088
+
+TURNSTILE_TEST_SITE_KEY="1x00000000000000000000AA"
+TURNSTILE_TEST_SECRET_KEY="1x0000000000000000000000000000000AA"
+TURNSTILE_TEST_TOKEN="XXXX.DUMMY.TOKEN.XXXX"
+
+TURNSTILE_MODE=""
+TURNSTILE_MODE_DETAIL=""
+TURNSTILE_SITE_KEY_EFFECTIVE=""
+TURNSTILE_SECRET_KEY_EFFECTIVE=""
+TURNSTILE_TOKEN="${REAL_E2E_TURNSTILE_TOKEN:-}"
+
+require_env() {
+  if [[ -z "${!1:-}" ]]; then
+    echo "missing required environment variable: $1" >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  docker compose --env-file "${ENV_FILE}" -f "${ROOT_DIR}/dev/docker-compose.yml" -f "${TMP_DIR}/override.yml" down -v >/dev/null 2>&1 || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+run_curl() {
+  local outfile="$1"
+  local method="$2"
+  local url="$3"
+  shift 3
+  HTTP_STATUS="$(curl -sS -o "${outfile}" -w "%{http_code}" -X "${method}" "${url}" "$@")"
+}
+
+assert_status() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${label}: expected HTTP ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_status_class_4xx() {
+  local actual="$1"
+  local label="$2"
+  if [[ ! "${actual}" =~ ^4[0-9][0-9]$ ]]; then
+    echo "${label}: expected 4xx, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+wait_for_status() {
+  local base_url="$1"
+  local path="$2"
+  local expected="$3"
+  local label="$4"
+  local outfile="${TMP_DIR}/wait.out"
+  local attempt
+  for attempt in $(seq 1 90); do
+    if run_curl "${outfile}" GET "${base_url}${path}"; then
+      if [[ "${HTTP_STATUS}" == "${expected}" ]]; then
+        echo "${label}: HTTP ${expected}"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "${label}: service did not become ready" >&2
+  exit 1
+}
+
+extract_json_field() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data[sys.argv[2]]
+if isinstance(value, (dict, list)):
+    raise SystemExit(f"field {sys.argv[2]} must be scalar")
+print(value)
+PY
+}
+
+configure_turnstile_mode() {
+  if [[ -n "${REAL_E2E_TURNSTILE_TOKEN:-}" ]]; then
+    require_env TURNSTILE_SECRET_KEY
+    TURNSTILE_MODE="full-real"
+    TURNSTILE_MODE_DETAIL="REAL_E2E_TURNSTILE_TOKEN"
+    TURNSTILE_SITE_KEY_EFFECTIVE="${TURNSTILE_SITE_KEY:-${TURNSTILE_TEST_SITE_KEY}}"
+    TURNSTILE_SECRET_KEY_EFFECTIVE="${TURNSTILE_SECRET_KEY}"
+    TURNSTILE_TOKEN="${REAL_E2E_TURNSTILE_TOKEN}"
+    return 0
+  fi
+
+  TURNSTILE_MODE="half-real"
+  TURNSTILE_MODE_DETAIL="dummy-turnstile-real-firebase"
+  TURNSTILE_SITE_KEY_EFFECTIVE="${TURNSTILE_TEST_SITE_KEY}"
+  TURNSTILE_SECRET_KEY_EFFECTIVE="${TURNSTILE_TEST_SECRET_KEY}"
+  TURNSTILE_TOKEN="${TURNSTILE_TEST_TOKEN}"
+}
+
+check_logs_for_secret() {
+  local compose_log="${TMP_DIR}/compose.log"
+  docker compose --env-file "${ENV_FILE}" -f "${ROOT_DIR}/dev/docker-compose.yml" -f "${TMP_DIR}/override.yml" logs --no-color \
+    > "${compose_log}" 2>/dev/null || true
+
+  local marker
+  for marker in \
+    "${TURNSTILE_SECRET_KEY:-}" \
+    "${GOOGLE_SERVICE_ACCOUNT_JSON_BASE64}" \
+    "${TURNSTILE_TOKEN:-}" \
+    "${APP_CHECK_TOKEN:-}"; do
+    if [[ -n "${marker}" ]] && grep -Fq "${marker}" "${compose_log}"; then
+      echo "compose logs leaked a secret or token" >&2
+      exit 1
+    fi
+  done
+}
+
+require_env FIREBASE_PROJECT_ID
+require_env FIREBASE_APP_ID
+require_env GOOGLE_SERVICE_ACCOUNT_JSON_BASE64
+
+configure_turnstile_mode
+
+cat > "${ENV_FILE}" <<EOF
+TRAEFIK_PORT=8080
+TRAEFIK_DASHBOARD_PORT=8088
+APPCHECK_SUBPATH=/appcheck
+LOG_LEVEL=info
+REQUEST_TIMEOUT=10s
+APPCHECK_TOKEN_TTL=30m
+TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY_EFFECTIVE}
+TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY_EFFECTIVE}
+TURNSTILE_SITEVERIFY_URL=https://challenges.cloudflare.com/turnstile/v0/siteverify
+FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
+FIREBASE_APP_ID=${FIREBASE_APP_ID}
+FIREBASE_APP_RESOURCE=${FIREBASE_APP_RESOURCE:-}
+GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=${GOOGLE_SERVICE_ACCOUNT_JSON_BASE64}
+TRUST_PROXY_HEADERS=true
+VERIFY_HEADER_NAME=X-Firebase-AppCheck
+VERIFY_SUCCESS_STATUS=204
+VERIFY_FAILURE_STATUS=401
+HEALTH_PATH=/healthz
+READY_PATH=/readyz
+ADMIN_DASHBOARD_ENABLED=true
+ADMIN_BASE_PATH=/admin
+ADMIN_AUDIT_TIMESTAMP_FORMAT=2006-01-02 15:04:05 MST
+ADMIN_AUDIT_TIMESTAMP_TIMEZONE=Asia/Tokyo
+ADMIN_AUTH_MODE=header
+ADMIN_AUTH_USER_HEADER=X-Forwarded-User
+ADMIN_AUTH_EMAIL_HEADER=X-Forwarded-Email
+ADMIN_AUTH_GROUPS_HEADER=X-Forwarded-Groups
+ADMIN_ALLOWED_USERS=
+ADMIN_ALLOWED_GROUPS=gateway-admins
+AUDIT_ENABLED=true
+AUDIT_SQLITE_PATH=/var/lib/turnstile-appcheck-gateway/audit.db
+AUDIT_RETENTION_DAYS=90
+RATE_LIMIT_ENABLED=false
+RATE_LIMIT_REQUESTS=120
+RATE_LIMIT_WINDOW=1m
+EOF
+
+cat > "${TMP_DIR}/override.yml" <<EOF
+services:
+  turnstile-appcheck-gateway:
+    environment:
+      TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY_EFFECTIVE}
+      ADMIN_AUTH_MODE: header
+      ADMIN_ALLOWED_GROUPS: gateway-admins
+      AUDIT_SQLITE_PATH: /var/lib/turnstile-appcheck-gateway/audit.db
+      RATE_LIMIT_ENABLED: "false"
+    labels:
+      - "traefik.http.routers.appcheck-health.rule=Path(\`/healthz\`)"
+      - "traefik.http.routers.appcheck-health.entrypoints=web"
+      - "traefik.http.routers.appcheck-health.priority=110"
+      - "traefik.http.routers.appcheck-ready.rule=Path(\`/readyz\`)"
+      - "traefik.http.routers.appcheck-ready.entrypoints=web"
+      - "traefik.http.routers.appcheck-ready.priority=110"
+  frontend:
+    environment:
+      TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY_EFFECTIVE}
+    labels:
+      - "traefik.http.routers.frontend.rule=PathPrefix(\`/\`) && !PathPrefix(\`/appcheck\`) && !PathPrefix(\`/backend\`) && !Path(\`/healthz\`) && !Path(\`/readyz\`)"
+EOF
+
+BASE_URL="http://localhost:8080"
+docker compose --env-file "${ENV_FILE}" -f "${ROOT_DIR}/dev/docker-compose.yml" -f "${TMP_DIR}/override.yml" up -d --build
+
+wait_for_status "${BASE_URL}" "/healthz" "200" "healthz"
+wait_for_status "${BASE_URL}" "/readyz" "200" "readyz"
+
+echo "turnstile mode: ${TURNSTILE_MODE} (${TURNSTILE_MODE_DETAIL})"
+
+cat > "${TMP_DIR}/exchange-valid.json" <<JSON
+{"turnstileToken":"${TURNSTILE_TOKEN}","limitedUse":false}
+JSON
+run_curl "${TMP_DIR}/exchange-valid.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_DIR}/exchange-valid.json"
+assert_status "200" "${HTTP_STATUS}" "exchange valid"
+APP_CHECK_TOKEN="$(extract_json_field "${TMP_DIR}/exchange-valid.out" token)"
+EXPIRE_TIME_MILLIS="$(extract_json_field "${TMP_DIR}/exchange-valid.out" expireTimeMillis)"
+if [[ -z "${APP_CHECK_TOKEN}" || -z "${EXPIRE_TIME_MILLIS}" ]]; then
+  echo "exchange valid: missing token or expireTimeMillis" >&2
+  exit 1
+fi
+echo "exchange valid: HTTP 200"
+
+run_curl "${TMP_DIR}/verify-valid.out" GET "${BASE_URL}/appcheck/api/v1/verify" \
+  -H "X-Firebase-AppCheck: ${APP_CHECK_TOKEN}"
+assert_status "204" "${HTTP_STATUS}" "verify valid"
+echo "verify valid: HTTP 204"
+
+if [[ "${TURNSTILE_MODE}" == "full-real" ]]; then
+  run_curl "${TMP_DIR}/exchange-invalid.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+    -H "Content-Type: application/json" \
+    --data-binary '{"turnstileToken":"invalid-token","limitedUse":false}'
+  assert_status_class_4xx "${HTTP_STATUS}" "exchange invalid token"
+  echo "exchange invalid token: HTTP ${HTTP_STATUS}"
+else
+  echo "exchange invalid token: skipped in half-real mode"
+fi
+
+run_curl "${TMP_DIR}/exchange-unknown.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+  -H "Content-Type: application/json" \
+  --data-binary '{"turnstileToken":"invalid-token","limitedUse":false,"unexpected":"attack"}'
+assert_status "400" "${HTTP_STATUS}" "exchange unknown field"
+echo "exchange unknown field: HTTP 400"
+
+run_curl "${TMP_DIR}/verify-invalid.out" GET "${BASE_URL}/appcheck/api/v1/verify" \
+  -H "X-Firebase-AppCheck: invalid-token"
+assert_status "401" "${HTTP_STATUS}" "verify invalid token"
+echo "verify invalid token: HTTP 401"
+
+check_logs_for_secret
+echo "log sanitization: OK"

--- a/scripts/e2e-smoke-mock.sh
+++ b/scripts/e2e-smoke-mock.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_URL="${1:-}"
+if [[ -z "${BASE_URL}" ]]; then
+  echo "usage: $0 <base-url>" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+HTTP_STATUS=""
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+run_curl() {
+  local outfile="$1"
+  local method="$2"
+  local url="$3"
+  shift 3
+  HTTP_STATUS="$(curl -sS -o "${outfile}" -w "%{http_code}" -X "${method}" "${url}" "$@")"
+}
+
+assert_status() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${label}: expected HTTP ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+wait_for_status() {
+  local path="$1"
+  local expected="$2"
+  local label="$3"
+  local outfile="${TMP_DIR}/wait.out"
+  local attempt
+  for attempt in $(seq 1 60); do
+    if run_curl "${outfile}" GET "${BASE_URL}${path}"; then
+      if [[ "${HTTP_STATUS}" == "${expected}" ]]; then
+        echo "${label}: HTTP ${expected}"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "${label}: service did not become ready" >&2
+  exit 1
+}
+
+extract_json_field() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data[sys.argv[2]]
+if isinstance(value, (dict, list)):
+    raise SystemExit(f"field {sys.argv[2]} must be scalar")
+print(value)
+PY
+}
+
+assert_audit_sanitized() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+for banned in (
+    "e2e-turnstile-pass",
+    "e2e-turnstile-fail",
+    "e2e-appcheck-valid-token",
+    "Bearer ",
+    "cookie",
+):
+    if banned in text:
+        raise SystemExit(f"audit response leaked sensitive marker: {banned}")
+PY
+}
+
+ADMIN_HEADERS=(
+  -H "X-Forwarded-User: e2e-admin"
+  -H "X-Forwarded-Email: e2e-admin@example.com"
+  -H "X-Forwarded-Groups: gateway-admins"
+)
+
+wait_for_status "/healthz" "200" "healthz"
+wait_for_status "/readyz" "200" "readyz"
+
+cat > "${TMP_DIR}/exchange-valid.json" <<'JSON'
+{"turnstileToken":"e2e-turnstile-pass","limitedUse":false}
+JSON
+run_curl "${TMP_DIR}/exchange-valid.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_DIR}/exchange-valid.json"
+assert_status "200" "${HTTP_STATUS}" "exchange valid"
+APP_CHECK_TOKEN="$(extract_json_field "${TMP_DIR}/exchange-valid.out" token)"
+EXPIRE_TIME_MILLIS="$(extract_json_field "${TMP_DIR}/exchange-valid.out" expireTimeMillis)"
+if [[ -z "${APP_CHECK_TOKEN}" || -z "${EXPIRE_TIME_MILLIS}" ]]; then
+  echo "exchange valid: missing token or expireTimeMillis" >&2
+  exit 1
+fi
+echo "exchange valid: HTTP 200"
+
+run_curl "${TMP_DIR}/verify-valid.out" GET "${BASE_URL}/appcheck/api/v1/verify" \
+  -H "X-Firebase-AppCheck: ${APP_CHECK_TOKEN}"
+assert_status "204" "${HTTP_STATUS}" "verify valid"
+echo "verify valid: HTTP 204"
+
+run_curl "${TMP_DIR}/verify-missing.out" GET "${BASE_URL}/appcheck/api/v1/verify"
+assert_status "401" "${HTTP_STATUS}" "verify missing token"
+echo "verify missing token: HTTP 401"
+
+run_curl "${TMP_DIR}/verify-invalid.out" POST "${BASE_URL}/appcheck/api/v1/verify" \
+  -H "X-Firebase-AppCheck: invalid-token"
+assert_status "401" "${HTTP_STATUS}" "verify invalid token"
+echo "verify invalid token: HTTP 401"
+
+cat > "${TMP_DIR}/exchange-fail.json" <<'JSON'
+{"turnstileToken":"e2e-turnstile-fail","limitedUse":false}
+JSON
+run_curl "${TMP_DIR}/exchange-fail.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_DIR}/exchange-fail.json"
+assert_status "400" "${HTTP_STATUS}" "exchange invalid token"
+echo "exchange invalid token: HTTP 400"
+
+cat > "${TMP_DIR}/exchange-unknown.json" <<'JSON'
+{"turnstileToken":"e2e-turnstile-pass","limitedUse":false,"unexpected":"attack"}
+JSON
+run_curl "${TMP_DIR}/exchange-unknown.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_DIR}/exchange-unknown.json"
+assert_status "400" "${HTTP_STATUS}" "exchange unknown field"
+echo "exchange unknown field: HTTP 400"
+
+run_curl "${TMP_DIR}/exchange-text.out" POST "${BASE_URL}/appcheck/api/v1/exchange" \
+  -H "Content-Type: text/plain" \
+  --data-binary 'turnstileToken=e2e-turnstile-pass'
+assert_status "415" "${HTTP_STATUS}" "exchange wrong content type"
+echo "exchange wrong content type: HTTP 415"
+
+run_curl "${TMP_DIR}/admin-page.out" GET "${BASE_URL}/appcheck/admin/" "${ADMIN_HEADERS[@]}"
+assert_status "200" "${HTTP_STATUS}" "admin dashboard"
+echo "admin dashboard: HTTP 200"
+
+run_curl "${TMP_DIR}/admin-metrics.out" GET "${BASE_URL}/appcheck/_admin/api/v1/request-metrics" "${ADMIN_HEADERS[@]}"
+assert_status "200" "${HTTP_STATUS}" "admin metrics"
+echo "admin metrics: HTTP 200"
+
+run_curl "${TMP_DIR}/admin-audit.out" GET "${BASE_URL}/appcheck/_admin/api/v1/audit-events?limit=20" "${ADMIN_HEADERS[@]}"
+assert_status "200" "${HTTP_STATUS}" "admin audit"
+assert_audit_sanitized "${TMP_DIR}/admin-audit.out"
+echo "admin audit sanitization: OK"

--- a/scripts/helm-e2e-kind.sh
+++ b/scripts/helm-e2e-kind.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-turnstile-appcheck-gateway-e2e}"
+NAMESPACE="${NAMESPACE:-appcheck-e2e}"
+RELEASE_NAME="${RELEASE_NAME:-turnstile-appcheck-gateway}"
+IMAGE_NAME="${IMAGE_NAME:-turnstile-appcheck-gateway:e2e}"
+LOCAL_PORT="${LOCAL_PORT:-18080}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/.tmp/kind-${CLUSTER_NAME}.kubeconfig}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
+KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
+PORT_FORWARD_PID=""
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+for cmd in docker kind kubectl helm curl python3; do
+  require_command "${cmd}"
+done
+
+mkdir -p "${ROOT_DIR}/.tmp"
+
+debug_dump() {
+  echo "collecting kind debug output" >&2
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get all || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get events --sort-by=.lastTimestamp || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" describe deploy "${RELEASE_NAME}" || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" logs deploy/"${RELEASE_NAME}" || true
+  helm --kubeconfig "${KUBECONFIG_PATH}" status "${RELEASE_NAME}" -n "${NAMESPACE}" || true
+}
+
+cleanup() {
+  local exit_code=$?
+
+  if [[ -n "${PORT_FORWARD_PID}" ]]; then
+    kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+    wait "${PORT_FORWARD_PID}" 2>/dev/null || true
+  fi
+
+  if [[ ${exit_code} -ne 0 ]]; then
+    debug_dump
+    if [[ "${KEEP_ON_FAILURE}" == "true" ]]; then
+      echo "kind resources preserved after failure" >&2
+      exit "${exit_code}"
+    fi
+  fi
+
+  if [[ ${exit_code} -eq 0 && "${KEEP_CLUSTER}" == "true" ]]; then
+    echo "kind resources preserved after success" >&2
+    exit 0
+  fi
+
+  kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  rm -f "${KUBECONFIG_PATH}"
+  exit "${exit_code}"
+}
+trap cleanup EXIT
+
+helm lint "${ROOT_DIR}/deploy/chart" \
+  --set-string secrets.TURNSTILE_SECRET_KEY=dummy \
+  --set-string secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=dummy
+
+if kind get clusters | grep -Fxq "${CLUSTER_NAME}"; then
+  kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_PATH}"
+else
+  kind create cluster --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PATH}"
+fi
+chmod 600 "${KUBECONFIG_PATH}"
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" get nodes
+
+docker build -t "${IMAGE_NAME}" "${ROOT_DIR}"
+kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace "${NAMESPACE}" --dry-run=client -o yaml | \
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
+
+IMAGE_REPOSITORY="${IMAGE_NAME%:*}"
+IMAGE_TAG="${IMAGE_NAME##*:}"
+if [[ "${IMAGE_REPOSITORY}" == "${IMAGE_TAG}" ]]; then
+  IMAGE_TAG="latest"
+fi
+
+helm --kubeconfig "${KUBECONFIG_PATH}" upgrade --install "${RELEASE_NAME}" "${ROOT_DIR}/deploy/chart" \
+  -n "${NAMESPACE}" \
+  --wait \
+  --timeout 5m \
+  --set image.repository="${IMAGE_REPOSITORY}" \
+  --set image.tag="${IMAGE_TAG}" \
+  --set image.pullPolicy=IfNotPresent \
+  --set persistence.enabled=false \
+  --set-string config.ADMIN_AUTH_MODE=header \
+  --set-string config.ADMIN_ALLOWED_GROUPS=gateway-admins \
+  --set-string config.RATE_LIMIT_ENABLED=false \
+  --set-string secrets.TURNSTILE_SECRET_KEY=dummy \
+  --set-string secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=dummy \
+  --set extraEnv[0].name=E2E_UPSTREAM_MODE \
+  --set extraEnv[0].value=mock \
+  --set extraEnv[1].name=E2E_TURNSTILE_PASS_TOKEN \
+  --set extraEnv[1].value=e2e-turnstile-pass \
+  --set extraEnv[2].name=E2E_TURNSTILE_FAIL_TOKEN \
+  --set extraEnv[2].value=e2e-turnstile-fail \
+  --set extraEnv[3].name=E2E_APPCHECK_TOKEN \
+  --set extraEnv[3].value=e2e-appcheck-valid-token \
+  --set extraEnv[4].name=E2E_APPCHECK_APP_ID \
+  --set extraEnv[4].value=e2e-app-id
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" rollout status deploy/"${RELEASE_NAME}" --timeout=5m
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" port-forward svc/"${RELEASE_NAME}" "${LOCAL_PORT}:80" \
+  > "${ROOT_DIR}/.tmp/kind-port-forward.log" 2>&1 &
+PORT_FORWARD_PID=$!
+
+"${ROOT_DIR}/scripts/e2e-smoke-mock.sh" "http://127.0.0.1:${LOCAL_PORT}"


### PR DESCRIPTION
### Summary
- English
  - Add mock e2e coverage, release integration validation, and separated contributor-facing e2e/release documentation.
- Japanese
  - mock e2e、release integration validation、contributor 向け e2e / release ドキュメント分離を追加する。
### Why
- English
  - The gateway needs safer validation for PR and release flows, while the main README should stay focused on service consumers instead of CI and release operations.
- Japanese
  - gateway には PR / release 向けの安全な検証経路が必要であり、同時に main README は CI / release 運用ではなくサービス利用者向け情報に集中させたい。
