### PR TITLE
Recommend Secret-backed audit DSN in Helm chart

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -8,7 +8,7 @@ This chart installs `turnstile-appcheck-gateway`, a Go/Gin gateway that bridges 
 - `GET /readyz`
 - `GET {SUBPATH}/admin/` and `GET {SUBPATH}/_admin/api/v1/...` when the admin dashboard is enabled
 
-The chart separates non-sensitive runtime configuration into a `ConfigMap` and sensitive values into a `Secret`. It supports SQLite audit log persistence with a PVC, an ephemeral `emptyDir` mode, and external PostgreSQL or MariaDB/MySQL audit databases through `config.AUDIT_STORAGE_TYPE` and `config.AUDIT_DSN`.
+The chart separates non-sensitive runtime configuration into a `ConfigMap` and sensitive values into a `Secret`. It supports SQLite audit log persistence with a PVC, an ephemeral `emptyDir` mode, and external PostgreSQL or MariaDB/MySQL audit databases through `config.AUDIT_STORAGE_TYPE` and `secrets.AUDIT_DSN`.
 
 ## Prerequisites
 
@@ -203,12 +203,14 @@ The audit log is designed not to store secret values, tokens, service account JS
 
 PostgreSQL is recommended for production and high-frequency `/verify` traffic:
 
+Because PostgreSQL and MariaDB/MySQL DSNs usually contain credentials, set `secrets.AUDIT_DSN` instead of `config.AUDIT_DSN`. `config.AUDIT_DSN` remains available for non-sensitive SQLite DSN overrides and backward compatibility. When `existingSecret` is used, include an `AUDIT_DSN` key in that Secret.
+
 ```bash
 helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
   --namespace appcheck \
   --create-namespace \
   --set config.AUDIT_STORAGE_TYPE=postgres \
-  --set config.AUDIT_DSN='postgres://user:password@postgres:5432/turnstile_appcheck_gateway?sslmode=disable' \
+  --set-string secrets.AUDIT_DSN='postgres://user:password@postgres:5432/turnstile_appcheck_gateway?sslmode=disable' \
   --set config.AUDIT_DB_MAX_OPEN_CONNS=20 \
   --set config.AUDIT_DB_MAX_IDLE_CONNS=10 \
   --set config.AUDIT_DB_CONN_MAX_LIFETIME=30m \
@@ -222,7 +224,7 @@ helm upgrade --install turnstile-appcheck-gateway ./deploy/chart \
   --namespace appcheck \
   --create-namespace \
   --set config.AUDIT_STORAGE_TYPE=mariadb \
-  --set config.AUDIT_DSN='user:password@tcp(mariadb:3306)/turnstile_appcheck_gateway?parseTime=true&charset=utf8mb4&loc=UTC'
+  --set-string secrets.AUDIT_DSN='user:password@tcp(mariadb:3306)/turnstile_appcheck_gateway?parseTime=true&charset=utf8mb4&loc=UTC'
 ```
 
 By default, `/verify` success audit rows are not stored one-by-one (`AUDIT_VERIFY_SUCCESS_SAMPLE_RATE=0.0`). They still update rollup metrics used by the admin dashboard. `/verify` failures, denials, missing/invalid token outcomes, and `rate_limit.denied` are persisted. `/exchange` final summaries are persisted by default, step events follow `AUDIT_PUBLIC_MODE`, and admin/audit events are always persisted.

--- a/deploy/chart/templates/secret.yaml
+++ b/deploy/chart/templates/secret.yaml
@@ -17,6 +17,9 @@ metadata:
 type: Opaque
 stringData:
   {{- range $key := keys .Values.secrets | sortAlpha }}
+  {{- $value := trim (printf "%v" (index $.Values.secrets $key)) }}
+  {{- if $value }}
   {{ $key }}: {{ index $.Values.secrets $key | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -125,6 +125,9 @@ config:
 
   AUDIT_ENABLED: "true"
   AUDIT_STORAGE_TYPE: "sqlite"
+  # Prefer secrets.AUDIT_DSN for PostgreSQL/MariaDB/MySQL because DSNs often
+  # contain credentials. config.AUDIT_DSN remains available for non-sensitive
+  # SQLite DSN overrides and backward compatibility.
   AUDIT_DSN: ""
   AUDIT_SQLITE_PATH: "/var/lib/turnstile-appcheck-gateway/audit.db"
   AUDIT_DB_MAX_OPEN_CONNS: ""
@@ -158,6 +161,8 @@ secrets:
   TURNSTILE_SECRET_KEY: ""
   GOOGLE_SERVICE_ACCOUNT_JSON: ""
   GOOGLE_SERVICE_ACCOUNT_JSON_BASE64: ""
+  # Recommended for PostgreSQL/MariaDB/MySQL audit storage.
+  AUDIT_DSN: ""
 
 existingSecret: ""
 


### PR DESCRIPTION
### Summary
- English
  - Updates the Helm chart to recommend `secrets.AUDIT_DSN` for PostgreSQL and MariaDB/MySQL audit storage DSNs.
- Japanese
  - PostgreSQL と MariaDB/MySQL の audit storage DSN は `secrets.AUDIT_DSN` を使うよう Helm chart を更新します。
### Why
- English
  - Audit DSNs often contain database credentials, so production examples should avoid placing them in ConfigMaps.
- Japanese
  - audit DSN は database credential を含むことが多いため、production example では ConfigMap に置かない案内にする必要があります。
