### PR TITLE
Audit flush retry safety and DB load coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,27 @@
-.git
-.gitignore
-.github
-README.md
-LICENSE
-*.log
-frontend/node_modules
-.data
+# Keep the Docker build context as an allowlist. The Dockerfile only needs
+# Go sources and frontend build inputs; local test results, compose files,
+# docs, git metadata, and generated artifacts should not invalidate builds.
+*
+
+!go.mod
+!go.sum
+
+!cmd/
+!cmd/**
+
+!internal/
+!internal/**
+internal/adminui/dist/**
+
+!frontend/
+!frontend/index.html
+!frontend/package.json
+!frontend/package-lock.json
+!frontend/tsconfig.json
+!frontend/vite.config.ts
+!frontend/public/
+!frontend/public/**
+!frontend/src/
+!frontend/src/**
+frontend/node_modules/**
+frontend/dist/**

--- a/.github/workflows/compose-e2e.yml
+++ b/.github/workflows/compose-e2e.yml
@@ -14,27 +14,39 @@ on:
       - "scripts/e2e-smoke-mock.sh"
       - "dev/docker-compose.yml"
       - "dev/docker-compose.e2e.yml"
+      - "dev/docker-compose.pg.yml"
+      - "dev/docker-compose.mariadb.yml"
       - "Makefile"
       - ".github/workflows/compose-e2e.yml"
 
 jobs:
   compose-e2e:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: sqlite
+            compose_db_file: ""
+          - name: postgres
+            compose_db_file: "-f dev/docker-compose.pg.yml"
+          - name: mariadb
+            compose_db_file: "-f dev/docker-compose.mariadb.yml"
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run compose mock e2e
+      - name: Run compose mock e2e (${{ matrix.name }})
         run: |
-          make compose-e2e-mock
+          make compose-e2e-mock COMPOSE_DB_FILE="${{ matrix.compose_db_file }}"
 
       - name: Show compose logs on failure
         if: failure()
         run: |
-          docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml ps || true
-          docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml logs || true
+          docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml ${{ matrix.compose_db_file }} ps || true
+          docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml ${{ matrix.compose_db_file }} logs || true
 
       - name: Stop compose stack
         if: always()
         run: |
-          make compose-e2e-down
+          make compose-e2e-down COMPOSE_DB_FILE="${{ matrix.compose_db_file }}"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,32 @@
-.PHONY: compose-e2e-mock compose-e2e-down e2e-kind-mock e2e-kind-keep e2e-kind-clean e2e-real-local act-release-e2e
+.PHONY: compose-e2e-mock compose-e2e-mock-pg compose-e2e-mock-mariadb compose-e2e-down compose-e2e-down-pg compose-e2e-down-mariadb audit-load-k6 e2e-kind-mock e2e-kind-keep e2e-kind-clean e2e-real-local act-release-e2e
+
+COMPOSE_E2E_BASE_FILES := -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml
+COMPOSE_E2E_FILES := $(COMPOSE_E2E_BASE_FILES) $(COMPOSE_DB_FILE)
 
 compose-e2e-mock:
 	cp -n dev/.env.example dev/.env || true
 	chmod +x scripts/e2e-smoke-mock.sh
-	docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml up -d --build
-	./scripts/e2e-smoke-mock.sh "http://127.0.0.1:$$(awk -F= '/^TRAEFIK_PORT=/{print $$2; found=1} END{if(!found) print 8080}' dev/.env)"
+	docker compose --env-file dev/.env $(COMPOSE_E2E_FILES) up -d --build
+	./scripts/e2e-smoke-mock.sh "http://127.0.0.1:$${TRAEFIK_PORT:-$$(awk -F= '/^TRAEFIK_PORT=/{print $$2; found=1} END{if(!found) print 8080}' dev/.env)}"
+
+compose-e2e-mock-pg:
+	$(MAKE) compose-e2e-mock COMPOSE_DB_FILE="-f dev/docker-compose.pg.yml"
+
+compose-e2e-mock-mariadb:
+	$(MAKE) compose-e2e-mock COMPOSE_DB_FILE="-f dev/docker-compose.mariadb.yml"
 
 compose-e2e-down:
-	docker compose --env-file dev/.env -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml down -v
+	docker compose --env-file dev/.env $(COMPOSE_E2E_FILES) down -v --remove-orphans
+
+compose-e2e-down-pg:
+	$(MAKE) compose-e2e-down COMPOSE_DB_FILE="-f dev/docker-compose.pg.yml"
+
+compose-e2e-down-mariadb:
+	$(MAKE) compose-e2e-down COMPOSE_DB_FILE="-f dev/docker-compose.mariadb.yml"
+
+audit-load-k6:
+	chmod +x scripts/k6-audit-load-matrix.sh
+	./scripts/k6-audit-load-matrix.sh
 
 e2e-kind-mock:
 	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh

--- a/dev/docker-compose.mariadb.yml
+++ b/dev/docker-compose.mariadb.yml
@@ -1,0 +1,29 @@
+services:
+  turnstile-appcheck-gateway:
+    environment:
+      AUDIT_STORAGE_TYPE: mariadb
+      AUDIT_DSN: turnstile:turnstile@tcp(mariadb:3306)/turnstile_appcheck_gateway?parseTime=true&charset=utf8mb4&loc=UTC
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+  mariadb:
+    image: mariadb:11.4
+    container_name: dev-mariadb
+    environment:
+      MARIADB_DATABASE: turnstile_appcheck_gateway
+      MARIADB_USER: turnstile
+      MARIADB_PASSWORD: turnstile
+      MARIADB_ROOT_PASSWORD: turnstile-root
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -h 127.0.0.1 -uturnstile -pturnstile --silent"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    networks:
+      - devnet
+    volumes:
+      - mariadb-data:/var/lib/mysql
+
+volumes:
+  mariadb-data:

--- a/dev/docker-compose.pg.yml
+++ b/dev/docker-compose.pg.yml
@@ -1,0 +1,28 @@
+services:
+  turnstile-appcheck-gateway:
+    environment:
+      AUDIT_STORAGE_TYPE: postgres
+      AUDIT_DSN: postgres://turnstile:turnstile@postgres:5432/turnstile_appcheck_gateway?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    container_name: dev-postgres
+    environment:
+      POSTGRES_DB: turnstile_appcheck_gateway
+      POSTGRES_USER: turnstile
+      POSTGRES_PASSWORD: turnstile
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U turnstile -d turnstile_appcheck_gateway"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    networks:
+      - devnet
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/docs/e2e-and-release.md
+++ b/docs/e2e-and-release.md
@@ -12,11 +12,16 @@ Commands:
 
 ```bash
 make compose-e2e-mock
+make compose-e2e-mock-pg
+make compose-e2e-mock-mariadb
 make compose-e2e-down
 make e2e-kind-mock
 ```
 
 `compose-e2e-mock` uses the Compose override in `dev/docker-compose.e2e.yml`.
+PostgreSQL and MariaDB audit storage variants add `dev/docker-compose.pg.yml` or `dev/docker-compose.mariadb.yml` with Compose `-f`.
+
+For k6 audit storage load tests, see [Load Testing](load-testing.md).
 
 `e2e-kind-mock` uses a repository-local kubeconfig under `.tmp/` and never targets `~/.kube/config`.
 
@@ -160,11 +165,16 @@ Pull Request CI は mock mode を使います。real Cloudflare Turnstile / Fire
 
 ```bash
 make compose-e2e-mock
+make compose-e2e-mock-pg
+make compose-e2e-mock-mariadb
 make compose-e2e-down
 make e2e-kind-mock
 ```
 
 `compose-e2e-mock` は `dev/docker-compose.e2e.yml` を使います。
+PostgreSQL / MariaDB の audit storage variant は `dev/docker-compose.pg.yml` または `dev/docker-compose.mariadb.yml` を Compose `-f` で追加します。
+
+k6 による audit storage load test は [Load Testing](load-testing.md) を参照してください。
 
 `e2e-kind-mock` は `.tmp/` 配下の repo-local kubeconfig を使い、`~/.kube/config` は使いません。
 

--- a/docs/load-test-results.md
+++ b/docs/load-test-results.md
@@ -1,0 +1,148 @@
+# k6 Audit Load Test Results - 2026-05-04
+
+These results were produced with the local Docker Compose k6 audit storage
+matrix. Each rate ran for `30s` against the mock e2e stack.
+
+## Summary
+
+- Async audit recording handled the configured targets cleanly in this run.
+- `verify-missing` with async audit reached `2000 rps` for both PostgreSQL and
+  MariaDB with no HTTP failures. PostgreSQL dropped 55 iterations out of a
+  60,000 target; MariaDB dropped none.
+- `exchange-valid` with async audit reached `500 rps` for both PostgreSQL and
+  MariaDB with no HTTP failures and no dropped iterations.
+- Sync audit recording was much more sensitive to database write latency.
+  PostgreSQL sync audit collapsed at `1000 rps`: only 54.9% of target
+  iterations completed, p95 latency was about 3.0s, and compose logs showed
+  PostgreSQL connection exhaustion/timeouts.
+- MariaDB sync audit performed better than PostgreSQL sync in this run, but
+  showed rising tail latency at `1000 rps` with p95 around 154ms.
+
+## Results
+
+| Case | DB | Async | Mode | Rate | Iterations | Target | Achieved | Dropped | p95 ms | p99 ms | Max ms |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | PostgreSQL | false | verify-missing | 100 | 3,001 | 3,000 | 100.0% | 0 | 2.70 | 3.98 | 33.41 |
+| 1 | PostgreSQL | false | verify-missing | 500 | 14,997 | 15,000 | 100.0% | 4 | 2.74 | 27.82 | 255.13 |
+| 1 | PostgreSQL | false | verify-missing | 1000 | 16,466 | 30,000 | 54.9% | 13,534 | 3,013.43 | 6,369.03 | 18,334.54 |
+| 2 | MariaDB | false | verify-missing | 100 | 3,001 | 3,000 | 100.0% | 0 | 2.94 | 6.10 | 41.58 |
+| 2 | MariaDB | false | verify-missing | 500 | 14,930 | 15,000 | 99.5% | 71 | 7.73 | 70.13 | 408.56 |
+| 2 | MariaDB | false | verify-missing | 1000 | 29,601 | 30,000 | 98.7% | 399 | 153.68 | 473.59 | 1,179.49 |
+| 3 | PostgreSQL | true | verify-missing | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.33 | 0.90 | 27.48 |
+| 3 | PostgreSQL | true | verify-missing | 1000 | 30,001 | 30,000 | 100.0% | 0 | 0.38 | 1.16 | 12.49 |
+| 3 | PostgreSQL | true | verify-missing | 2000 | 59,946 | 60,000 | 99.9% | 55 | 0.74 | 2.53 | 150.34 |
+| 4 | MariaDB | true | verify-missing | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.35 | 1.01 | 21.47 |
+| 4 | MariaDB | true | verify-missing | 1000 | 30,001 | 30,000 | 100.0% | 0 | 0.37 | 1.00 | 19.39 |
+| 4 | MariaDB | true | verify-missing | 2000 | 60,000 | 60,000 | 100.0% | 0 | 0.51 | 1.27 | 8.46 |
+| 5 | PostgreSQL | true | exchange-valid | 100 | 3,001 | 3,000 | 100.0% | 0 | 0.79 | 1.55 | 5.17 |
+| 5 | PostgreSQL | true | exchange-valid | 300 | 9,001 | 9,000 | 100.0% | 0 | 0.39 | 1.09 | 4.47 |
+| 5 | PostgreSQL | true | exchange-valid | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.37 | 1.23 | 12.15 |
+| 6 | MariaDB | true | exchange-valid | 100 | 3,001 | 3,000 | 100.0% | 0 | 0.62 | 0.88 | 3.41 |
+| 6 | MariaDB | true | exchange-valid | 300 | 9,001 | 9,000 | 100.0% | 0 | 0.45 | 0.92 | 36.78 |
+| 6 | MariaDB | true | exchange-valid | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.35 | 0.73 | 3.51 |
+
+## Interpretation
+
+The main behavioral difference is sync versus async audit writes.
+
+With sync audit, each request waits for audit persistence. At higher rates,
+database connection limits and write latency directly become API latency. In
+this run, PostgreSQL sync audit at `1000 rps` exceeded the local database
+capacity. The application logs included PostgreSQL `too many clients already`
+and TCP read timeout errors while recording audit events. MariaDB sync audit
+continued to complete nearly all requests at `1000 rps`, but tail latency was
+already materially higher than the lower-rate runs.
+
+With async audit, the request path only enqueues audit work. That keeps API
+latency low for these rates, while the recorder batches database writes in the
+background. This is the operating mode that matches high-throughput public
+verification traffic.
+
+## Caveats
+
+- This is a local Docker Compose result, not a production benchmark.
+- The duration was `30s` per rate, so this is a short stress pass rather than a
+  long soak test.
+- `verify-missing` intentionally treats HTTP `401` as a successful response in
+  k6, because the endpoint is expected to reject missing tokens.
+- `exchange-valid` uses mock upstreams from `dev/docker-compose.e2e.yml`; it
+  measures gateway and audit path behavior, not real Cloudflare/Firebase
+  upstream latency.
+- The PostgreSQL sync failure is still useful: it shows that sync audit writes
+  can exhaust the DB connection path under high request concurrency in this
+  environment.
+
+## Recommendation
+
+For public gateway traffic, keep `AUDIT_ASYNC_ENABLED=true`. Treat
+`AUDIT_ASYNC_ENABLED=false` as a diagnostic or low-throughput mode, especially
+when audit storage is PostgreSQL/MariaDB and every public request is counted.
+
+## Japanese
+
+### 概要
+
+この結果は、ローカル Docker Compose の k6 audit storage matrix で取得した
+ものです。各 rate は mock e2e stack に対して `30s` 実行しています。
+
+主な結論:
+
+- async audit recording は、この実行で設定した target を概ね問題なく処理しました。
+- `verify-missing` + async audit は PostgreSQL / MariaDB とも `2000 rps` まで到達しました。HTTP failure はありません。PostgreSQL は 60,000 target 中 55 iteration drop、MariaDB は drop なしでした。
+- `exchange-valid` + async audit は PostgreSQL / MariaDB とも `500 rps` まで到達しました。HTTP failure と dropped iteration はありません。
+- sync audit recording は DB write latency の影響を強く受けます。PostgreSQL sync audit の `1000 rps` は崩れており、target の 54.9% しか完了せず、p95 latency は約 3.0 秒でした。compose log には PostgreSQL の connection exhaustion / timeout が出ています。
+- MariaDB sync audit はこの実行では PostgreSQL sync より耐えましたが、`1000 rps` では p95 latency が約 154ms まで上がっています。
+
+### 結果
+
+| Case | DB | Async | Mode | Rate | Iterations | Target | Achieved | Dropped | p95 ms | p99 ms | Max ms |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | PostgreSQL | false | verify-missing | 100 | 3,001 | 3,000 | 100.0% | 0 | 2.70 | 3.98 | 33.41 |
+| 1 | PostgreSQL | false | verify-missing | 500 | 14,997 | 15,000 | 100.0% | 4 | 2.74 | 27.82 | 255.13 |
+| 1 | PostgreSQL | false | verify-missing | 1000 | 16,466 | 30,000 | 54.9% | 13,534 | 3,013.43 | 6,369.03 | 18,334.54 |
+| 2 | MariaDB | false | verify-missing | 100 | 3,001 | 3,000 | 100.0% | 0 | 2.94 | 6.10 | 41.58 |
+| 2 | MariaDB | false | verify-missing | 500 | 14,930 | 15,000 | 99.5% | 71 | 7.73 | 70.13 | 408.56 |
+| 2 | MariaDB | false | verify-missing | 1000 | 29,601 | 30,000 | 98.7% | 399 | 153.68 | 473.59 | 1,179.49 |
+| 3 | PostgreSQL | true | verify-missing | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.33 | 0.90 | 27.48 |
+| 3 | PostgreSQL | true | verify-missing | 1000 | 30,001 | 30,000 | 100.0% | 0 | 0.38 | 1.16 | 12.49 |
+| 3 | PostgreSQL | true | verify-missing | 2000 | 59,946 | 60,000 | 99.9% | 55 | 0.74 | 2.53 | 150.34 |
+| 4 | MariaDB | true | verify-missing | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.35 | 1.01 | 21.47 |
+| 4 | MariaDB | true | verify-missing | 1000 | 30,001 | 30,000 | 100.0% | 0 | 0.37 | 1.00 | 19.39 |
+| 4 | MariaDB | true | verify-missing | 2000 | 60,000 | 60,000 | 100.0% | 0 | 0.51 | 1.27 | 8.46 |
+| 5 | PostgreSQL | true | exchange-valid | 100 | 3,001 | 3,000 | 100.0% | 0 | 0.79 | 1.55 | 5.17 |
+| 5 | PostgreSQL | true | exchange-valid | 300 | 9,001 | 9,000 | 100.0% | 0 | 0.39 | 1.09 | 4.47 |
+| 5 | PostgreSQL | true | exchange-valid | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.37 | 1.23 | 12.15 |
+| 6 | MariaDB | true | exchange-valid | 100 | 3,001 | 3,000 | 100.0% | 0 | 0.62 | 0.88 | 3.41 |
+| 6 | MariaDB | true | exchange-valid | 300 | 9,001 | 9,000 | 100.0% | 0 | 0.45 | 0.92 | 36.78 |
+| 6 | MariaDB | true | exchange-valid | 500 | 15,001 | 15,000 | 100.0% | 0 | 0.35 | 0.73 | 3.51 |
+
+### 読み取り
+
+一番大きな差は sync audit と async audit の違いです。
+
+sync audit では、各 request が audit persistence を待ちます。そのため高い
+rate では、DB connection limit や write latency がそのまま API latency に
+なります。この実行では PostgreSQL sync audit の `1000 rps` がローカル DB の
+処理能力を超えました。application log には PostgreSQL の
+`too many clients already` と TCP read timeout が出ています。
+
+MariaDB sync audit は `1000 rps` でもほぼ全 request を完了できていますが、
+tail latency は低 rate と比べて明確に悪化しています。
+
+async audit では、request path は audit work を enqueue するだけです。そのため
+今回の rate では API latency が低く保たれ、recorder が background で batch
+write できます。public verification traffic のような高 throughput 用途では、
+この動作が望ましいです。
+
+### 注意点
+
+- これはローカル Docker Compose の結果であり、production benchmark ではありません。
+- 各 rate の duration は `30s` なので、長時間 soak test ではなく短時間 stress pass です。
+- `verify-missing` は token なし request を意図的に送るため、HTTP `401` を k6 上の成功 response として扱っています。
+- `exchange-valid` は `dev/docker-compose.e2e.yml` の mock upstream を使います。実 Cloudflare / Firebase の upstream latency は測っていません。
+- PostgreSQL sync の失敗は、sync audit write が高 concurrency で DB connection path を枯渇させ得ることを示す有用な結果です。
+
+### 推奨
+
+public gateway traffic では `AUDIT_ASYNC_ENABLED=true` を維持してください。
+`AUDIT_ASYNC_ENABLED=false` は diagnostic または low-throughput mode として扱うのが妥当です。特に audit storage が PostgreSQL / MariaDB で、public request をすべて audit 対象にする場合は async が前提になります。

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,55 @@
+# Load Testing
+
+## k6 audit storage matrix
+
+The audit load runner starts the mock compose stack with PostgreSQL or MariaDB,
+switches `AUDIT_ASYNC_ENABLED`, and runs k6 from inside the compose network.
+Results are written under `.tmp/k6-audit-load/<timestamp>/`.
+
+One captured result set is summarized in
+[k6 Audit Load Test Results - 2026-05-04](load-test-results-20260504.md).
+
+```bash
+make audit-load-k6
+```
+
+The default k6 duration is `30s` per rate. Override it when you want a longer
+run:
+
+```bash
+K6_DURATION=1m make audit-load-k6
+```
+
+The matrix is:
+
+| Case | DB | `AUDIT_ASYNC_ENABLED` | k6 mode | Rates |
+| --- | --- | --- | --- | --- |
+| 1 | PostgreSQL | `false` | `verify-missing` | `100`, `500`, `1000` |
+| 2 | MariaDB | `false` | `verify-missing` | `100`, `500`, `1000` |
+| 3 | PostgreSQL | `true` | `verify-missing` | `500`, `1000`, `2000` |
+| 4 | MariaDB | `true` | `verify-missing` | `500`, `1000`, `2000` |
+| 5 | PostgreSQL | `true` | `exchange-valid` | `100`, `300`, `500` |
+| 6 | MariaDB | `true` | `exchange-valid` | `100`, `300`, `500` |
+
+Each k6 run writes:
+
+- `summary.json`: raw k6 summary export
+- `k6.log`: stdout/stderr from k6
+- `summary.csv`: one row per case/rate with iterations, check rate, failed
+  request rate, and latency `avg`, `p90`, `p95`, `p99`, and `max`
+- `compose.log`: application and database logs for that case
+
+Useful overrides:
+
+```bash
+TRAEFIK_PORT=39080 TRAEFIK_DASHBOARD_PORT=39088 make audit-load-k6
+RESULT_ROOT=.tmp/my-load-run K6_DURATION=2m make audit-load-k6
+PRE_ALLOCATED_VUS=500 MAX_VUS=2000 make audit-load-k6
+KEEP_LOAD_STACK=true make audit-load-k6
+LOAD_CASES=1,3 K6_DURATION=10s make audit-load-k6
+LOAD_CASES=1 LOAD_RATES=100 K6_DURATION=5s make audit-load-k6
+```
+
+`verify-missing` expects HTTP `401`, so the k6 script marks that status as
+successful for `http_req_failed`. `exchange-valid` expects HTTP `200` and uses
+the mock Turnstile/App Check tokens from `dev/docker-compose.e2e.yml`.

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -100,6 +100,88 @@ func TestPruneRetention(t *testing.T) {
 	}
 }
 
+func TestAppendBatchDuplicateIDIsIdempotent(t *testing.T) {
+	store, err := bunrepo.Open(context.Background(), bunrepo.Config{StorageType: "sqlite", SQLitePath: filepath.Join(t.TempDir(), "audit.db")})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+
+	first := audit.Event{
+		ID:         "audit_duplicate_id",
+		Timestamp:  time.Date(2026, 5, 5, 1, 2, 3, 0, time.UTC),
+		Action:     "exchange.request",
+		Method:     "POST",
+		Endpoint:   "/api/v1/exchange",
+		StatusCode: 200,
+		Result:     audit.ResultSuccess,
+		RequestID:  "req-original",
+	}
+	changed := first
+	changed.Action = "verify.request"
+	changed.Endpoint = "/api/v1/verify"
+	changed.StatusCode = 401
+	changed.Result = audit.ResultFailure
+	changed.RequestID = "req-changed"
+
+	if err := store.AppendBatch(context.Background(), []audit.Event{first}); err != nil {
+		t.Fatalf("AppendBatch(first) error = %v", err)
+	}
+	if err := store.AppendBatch(context.Background(), []audit.Event{changed}); err != nil {
+		t.Fatalf("AppendBatch(duplicate) error = %v", err)
+	}
+	page, err := store.List(context.Background(), audit.Filter{IncludeTotal: true})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if page.Total != 1 || len(page.Items) != 1 {
+		t.Fatalf("duplicate id should not create a second row: %#v", page)
+	}
+	got := page.Items[0]
+	if got.Action != first.Action || got.Endpoint != first.Endpoint || got.StatusCode != first.StatusCode || got.RequestID != first.RequestID {
+		t.Fatalf("duplicate id should not overwrite original row: %#v", got)
+	}
+}
+
+func TestAppendAuditBatchPersistsEventsAndRollupsTogether(t *testing.T) {
+	store, err := bunrepo.Open(context.Background(), bunrepo.Config{StorageType: "sqlite", SQLitePath: filepath.Join(t.TempDir(), "audit.db")})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 5, 5, 1, 2, 3, 0, time.UTC)
+	event := audit.Event{
+		ID:         "audit_atomic_batch",
+		Timestamp:  now,
+		Action:     "exchange.request",
+		Method:     "POST",
+		Endpoint:   "/api/v1/exchange",
+		StatusCode: 200,
+		Result:     audit.ResultSuccess,
+	}
+	if err := store.AppendAuditBatch(context.Background(), []audit.Event{event}, []audit.MetricRollup{audit.NewMetricRollup(event)}); err != nil {
+		t.Fatalf("AppendAuditBatch() error = %v", err)
+	}
+	if err := store.AppendAuditBatch(context.Background(), []audit.Event{event}, []audit.MetricRollup{audit.NewMetricRollup(event)}); err != nil {
+		t.Fatalf("AppendAuditBatch(duplicate retry) error = %v", err)
+	}
+	page, err := store.List(context.Background(), audit.Filter{IncludeTotal: true})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if page.Total != 1 {
+		t.Fatalf("duplicate retry should keep one event row: %#v", page)
+	}
+	metrics, err := store.Metrics(context.Background(), audit.MetricsFilter{From: now.Add(-time.Minute), To: now.Add(time.Minute), Bucket: time.Minute})
+	if err != nil {
+		t.Fatalf("Metrics() error = %v", err)
+	}
+	if metrics.Summary.Total != 2 || metrics.Summary.ExchangeSuccesses != 2 {
+		t.Fatalf("retry rollup count should be accumulated exactly once per successful batch call: %#v", metrics.Summary)
+	}
+}
+
 func pageID(t *testing.T, store *bunrepo.Repository) string {
 	t.Helper()
 	page, err := store.List(context.Background(), audit.Filter{Limit: 1})

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -146,6 +146,10 @@ type Repository interface {
 	PruneRetention(context.Context, int) error
 }
 
+type AtomicBatchRepository interface {
+	AppendAuditBatch(context.Context, []Event, []MetricRollup) error
+}
+
 type CloseRepository interface {
 	Repository
 	Close() error

--- a/internal/audit/recorder.go
+++ b/internal/audit/recorder.go
@@ -40,12 +40,17 @@ func (r *SyncRecorder) Record(ctx context.Context, event Event) error {
 		return err
 	}
 	decision := r.policy.Decide(event)
+	var rollup *MetricRollup
 	if decision.CountMetric {
-		if err := r.repo.AppendMetricRollups(ctx, []MetricRollup{NewMetricRollup(event)}); err != nil {
-			return err
-		}
+		value := NewMetricRollup(event)
+		rollup = &value
 	}
 	if !decision.Persist {
+		if rollup != nil {
+			if err := r.repo.AppendMetricRollups(ctx, []MetricRollup{*rollup}); err != nil {
+				return err
+			}
+		}
 		r.stats.PolicySkippedTotal.Add(1)
 		if decision.SampledOut {
 			r.stats.SampledOutTotal.Add(1)
@@ -53,6 +58,14 @@ func (r *SyncRecorder) Record(ctx context.Context, event Event) error {
 		return nil
 	}
 	r.stats.EnqueueTotal.Add(1)
+	if rollup != nil {
+		if repo, ok := r.repo.(AtomicBatchRepository); ok {
+			return repo.AppendAuditBatch(ctx, []Event{event}, []MetricRollup{*rollup})
+		}
+		if err := r.repo.AppendMetricRollups(ctx, []MetricRollup{*rollup}); err != nil {
+			return err
+		}
+	}
 	return r.repo.AppendBatch(ctx, []Event{event})
 }
 
@@ -468,6 +481,24 @@ func (r *AsyncRecorder) flushWithRetry(ctx context.Context, events []Event, roll
 }
 
 func (r *AsyncRecorder) flushOnce(ctx context.Context, events []Event, rollups []MetricRollup) error {
+	if repo, ok := r.repo.(AtomicBatchRepository); ok {
+		if err := repo.AppendAuditBatch(ctx, events, rollups); err != nil {
+			if len(events) > 0 {
+				r.stats.FlushErrorTotal.Add(1)
+			}
+			if len(rollups) > 0 {
+				r.stats.RollupFlushError.Add(1)
+			}
+			return fmt.Errorf("append audit batch: %w", err)
+		}
+		if len(events) > 0 {
+			r.stats.FlushTotal.Add(1)
+		}
+		if len(rollups) > 0 {
+			r.stats.RollupFlushTotal.Add(1)
+		}
+		return nil
+	}
 	if len(events) > 0 {
 		if err := r.repo.AppendBatch(ctx, events); err != nil {
 			r.stats.FlushErrorTotal.Add(1)

--- a/internal/audit/recorder_test.go
+++ b/internal/audit/recorder_test.go
@@ -104,6 +104,66 @@ func TestAsyncRecorderRetryBehavior(t *testing.T) {
 	}
 }
 
+func TestAsyncRecorderRetrySurvivesPartialFlushDuplicateEventID(t *testing.T) {
+	repo := newPartialFlushRepo()
+	rec := NewAsyncRecorder(repo, NewPolicy(PolicyConfig{}), AsyncConfig{
+		ChannelSize:         10,
+		BatchSize:           10,
+		FlushInterval:       time.Hour,
+		RetryMaxAttempts:    2,
+		RetryInitialBackoff: time.Millisecond,
+		RetryMaxBackoff:     time.Millisecond,
+	})
+	defer rec.Close(context.Background())
+
+	first := Event{
+		ID:         "audit_retry_same_id",
+		Timestamp:  time.Date(2026, 5, 5, 1, 2, 3, 0, time.UTC),
+		Action:     "exchange.request",
+		Method:     "POST",
+		Endpoint:   "/api/v1/exchange",
+		StatusCode: 200,
+		Result:     ResultSuccess,
+	}
+	if err := rec.Record(context.Background(), first); err != nil {
+		t.Fatalf("Record(first) error = %v", err)
+	}
+	if err := rec.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush(first) error = %v", err)
+	}
+	if got := repo.eventCount(); got != 1 {
+		t.Fatalf("event count after retry = %d", got)
+	}
+	if got := repo.rollupCount(); got != 1 {
+		t.Fatalf("rollup count after retry = %d", got)
+	}
+
+	second := Event{
+		ID:         "audit_retry_next_id",
+		Timestamp:  first.Timestamp.Add(time.Minute),
+		Action:     "exchange.request",
+		Method:     "POST",
+		Endpoint:   "/api/v1/exchange",
+		StatusCode: 200,
+		Result:     ResultSuccess,
+	}
+	if err := rec.Record(context.Background(), second); err != nil {
+		t.Fatalf("Record(second) error = %v", err)
+	}
+	if err := rec.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush(second) error = %v", err)
+	}
+	if got := repo.eventCount(); got != 2 {
+		t.Fatalf("event count after following flush = %d", got)
+	}
+	if got := repo.rollupCount(); got != 2 {
+		t.Fatalf("rollup count after following flush = %d", got)
+	}
+	if rec.stats.RetryTotal.Load() == 0 {
+		t.Fatal("expected retry path to be exercised")
+	}
+}
+
 type fakeRepo struct {
 	mu       sync.Mutex
 	events   []Event
@@ -133,6 +193,12 @@ func (r *fakeRepo) eventCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.events)
+}
+
+func (r *fakeRepo) rollupCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rollups)
 }
 
 func (r *fakeRepo) Get(context.Context, string) (Event, bool, error) { return Event{}, false, nil }
@@ -165,4 +231,98 @@ func (r *blockingRepo) AppendMetricRollups(ctx context.Context, rollups []Metric
 		return ctx.Err()
 	}
 	return r.fakeRepo.AppendMetricRollups(ctx, rollups)
+}
+
+type partialFlushRepo struct {
+	mu              sync.Mutex
+	events          []Event
+	eventsByID      map[string]Event
+	rollups         []MetricRollup
+	failRollupsOnce bool
+}
+
+func newPartialFlushRepo() *partialFlushRepo {
+	return &partialFlushRepo{
+		eventsByID:      map[string]Event{},
+		failRollupsOnce: true,
+	}
+}
+
+func (r *partialFlushRepo) AppendAuditBatch(_ context.Context, events []Event, rollups []MetricRollup) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, event := range events {
+		if existing, ok := r.eventsByID[event.ID]; ok {
+			if !sameRetryEvent(existing, event) {
+				return errors.New("duplicate audit event id with different payload")
+			}
+			continue
+		}
+		r.eventsByID[event.ID] = event
+		r.events = append(r.events, event)
+	}
+	if r.failRollupsOnce {
+		r.failRollupsOnce = false
+		return errors.New("temporary rollup failure after event insert")
+	}
+	r.rollups = append(r.rollups, rollups...)
+	return nil
+}
+
+func (r *partialFlushRepo) AppendBatch(_ context.Context, events []Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, event := range events {
+		if _, ok := r.eventsByID[event.ID]; ok {
+			return errors.New("duplicate audit event id")
+		}
+		r.eventsByID[event.ID] = event
+		r.events = append(r.events, event)
+	}
+	return nil
+}
+
+func (r *partialFlushRepo) AppendMetricRollups(_ context.Context, rollups []MetricRollup) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rollups = append(r.rollups, rollups...)
+	return nil
+}
+
+func (r *partialFlushRepo) eventCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+func (r *partialFlushRepo) rollupCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rollups)
+}
+
+func (r *partialFlushRepo) Get(context.Context, string) (Event, bool, error) {
+	return Event{}, false, nil
+}
+func (r *partialFlushRepo) List(context.Context, Filter) (Page, error) {
+	return Page{}, nil
+}
+func (r *partialFlushRepo) Summary(context.Context, Filter) (Summary, error) {
+	return Summary{}, nil
+}
+func (r *partialFlushRepo) Metrics(context.Context, MetricsFilter) (Metrics, error) {
+	return Metrics{}, nil
+}
+func (r *partialFlushRepo) Reset(context.Context, Event) error        { return nil }
+func (r *partialFlushRepo) PruneRetention(context.Context, int) error { return nil }
+
+func sameRetryEvent(a, b Event) bool {
+	return a.ID == b.ID &&
+		a.Timestamp.Equal(b.Timestamp) &&
+		a.Action == b.Action &&
+		a.Method == b.Method &&
+		a.Endpoint == b.Endpoint &&
+		a.StatusCode == b.StatusCode &&
+		a.Result == b.Result &&
+		a.RequestID == b.RequestID
 }

--- a/internal/audit/storage/bunrepo/repository.go
+++ b/internal/audit/storage/bunrepo/repository.go
@@ -19,20 +19,12 @@ func (r *Repository) AppendBatch(ctx context.Context, events []audit.Event) erro
 	if r == nil || r.db == nil || len(events) == 0 {
 		return nil
 	}
-	models := make([]auditEventModel, 0, len(events))
-	for _, event := range events {
-		if err := audit.PrepareEvent(&event); err != nil {
-			return err
-		}
-		model, err := toEventModel(event)
-		if err != nil {
-			return err
-		}
-		models = append(models, model)
+	models, err := prepareEventModels(events)
+	if err != nil {
+		return err
 	}
 	return r.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		_, err := tx.NewInsert().Model(&models).Exec(ctx)
-		return err
+		return r.insertEventModels(ctx, tx, models)
 	})
 }
 
@@ -40,6 +32,48 @@ func (r *Repository) AppendMetricRollups(ctx context.Context, rollups []audit.Me
 	if r == nil || r.db == nil || len(rollups) == 0 {
 		return nil
 	}
+	models := prepareRollupModels(rollups)
+	if len(models) == 0 {
+		return nil
+	}
+	return r.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		return r.upsertRollupModels(ctx, tx, models)
+	})
+}
+
+func (r *Repository) AppendAuditBatch(ctx context.Context, events []audit.Event, rollups []audit.MetricRollup) error {
+	if r == nil || r.db == nil || (len(events) == 0 && len(rollups) == 0) {
+		return nil
+	}
+	eventModels, err := prepareEventModels(events)
+	if err != nil {
+		return err
+	}
+	rollupModels := prepareRollupModels(rollups)
+	return r.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if err := r.insertEventModels(ctx, tx, eventModels); err != nil {
+			return err
+		}
+		return r.upsertRollupModels(ctx, tx, rollupModels)
+	})
+}
+
+func prepareEventModels(events []audit.Event) ([]auditEventModel, error) {
+	models := make([]auditEventModel, 0, len(events))
+	for _, event := range events {
+		if err := audit.PrepareEvent(&event); err != nil {
+			return nil, err
+		}
+		model, err := toEventModel(event)
+		if err != nil {
+			return nil, err
+		}
+		models = append(models, model)
+	}
+	return models, nil
+}
+
+func prepareRollupModels(rollups []audit.MetricRollup) []metricRollupModel {
 	merged := mergeRollups(rollups)
 	models := make([]metricRollupModel, 0, len(merged))
 	for _, rollup := range merged {
@@ -48,24 +82,43 @@ func (r *Repository) AppendMetricRollups(ctx context.Context, rollups []audit.Me
 		}
 		models = append(models, toRollupModel(rollup))
 	}
+	return models
+}
+
+func (r *Repository) insertEventModels(ctx context.Context, tx bun.Tx, models []auditEventModel) error {
 	if len(models) == 0 {
 		return nil
 	}
-	return r.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		query := tx.NewInsert().Model(&models)
-		switch r.helper.name {
-		case dialectMySQL:
-			query = query.On("DUPLICATE KEY UPDATE count = count + VALUES(count)")
-		case dialectSQLite:
-			query = query.On("CONFLICT (bucket_start, bucket_size, endpoint, method, action, result, status_class, status_code) DO UPDATE").
-				Set("count = count + excluded.count")
-		default:
-			query = query.On("CONFLICT (bucket_start, bucket_size, endpoint, method, action, result, status_class, status_code) DO UPDATE").
-				Set("count = audit_metric_rollups.count + EXCLUDED.count")
-		}
-		_, err := query.Exec(ctx)
-		return err
-	})
+	query := tx.NewInsert().Model(&models)
+	// Duplicate IDs are replayed flush attempts. Keep the original audit row
+	// unchanged instead of turning a retry into a permanent writer failure.
+	switch r.helper.name {
+	case dialectMySQL:
+		query = query.On("DUPLICATE KEY UPDATE id = id")
+	default:
+		query = query.On("CONFLICT (id) DO NOTHING")
+	}
+	_, err := query.Exec(ctx)
+	return err
+}
+
+func (r *Repository) upsertRollupModels(ctx context.Context, tx bun.Tx, models []metricRollupModel) error {
+	if len(models) == 0 {
+		return nil
+	}
+	query := tx.NewInsert().Model(&models)
+	switch r.helper.name {
+	case dialectMySQL:
+		query = query.On("DUPLICATE KEY UPDATE count = count + VALUES(count)")
+	case dialectSQLite:
+		query = query.On("CONFLICT (bucket_start, bucket_size, endpoint, method, action, result, status_class, status_code) DO UPDATE").
+			Set("count = count + excluded.count")
+	default:
+		query = query.On("CONFLICT (bucket_start, bucket_size, endpoint, method, action, result, status_class, status_code) DO UPDATE").
+			Set("count = metric_rollup_model.count + EXCLUDED.count")
+	}
+	_, err := query.Exec(ctx)
+	return err
 }
 
 func (r *Repository) Get(ctx context.Context, id string) (audit.Event, bool, error) {

--- a/scripts/e2e-smoke-mock.sh
+++ b/scripts/e2e-smoke-mock.sh
@@ -83,6 +83,54 @@ for banned in (
 PY
 }
 
+assert_request_metrics_nonzero() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+summary = data.get("summary") or {}
+total = int(summary.get("total") or 0)
+exchange_successes = int(summary.get("exchangeSuccesses") or 0)
+points = data.get("points") or []
+point_total = sum(int(point.get("count") or 0) for point in points)
+if total < 1 or exchange_successes < 1 or point_total < 1:
+    raise SystemExit(f"request metrics did not include exchange rollups: summary={summary} pointTotal={point_total}")
+PY
+}
+
+assert_audit_events_nonzero() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+total = int(data.get("total") or 0)
+items = data.get("items") or []
+if total < 1 or not items:
+    raise SystemExit(f"audit events did not include persisted rows: total={total} items={len(items)}")
+PY
+}
+
+wait_for_request_metrics() {
+  local outfile="${TMP_DIR}/admin-metrics.out"
+  local attempt
+  for attempt in $(seq 1 30); do
+    run_curl "${outfile}" GET "${BASE_URL}/appcheck/_admin/api/v1/request-metrics" "${ADMIN_HEADERS[@]}"
+    if [[ "${HTTP_STATUS}" == "200" ]] && assert_request_metrics_nonzero "${outfile}" >/dev/null 2>&1; then
+      echo "admin metrics rollups: OK"
+      return 0
+    fi
+    sleep 1
+  done
+  assert_status "200" "${HTTP_STATUS}" "admin metrics"
+  assert_request_metrics_nonzero "${outfile}"
+}
+
 ADMIN_HEADERS=(
   -H "X-Forwarded-User: e2e-admin"
   -H "X-Forwarded-Email: e2e-admin@example.com"
@@ -149,11 +197,10 @@ run_curl "${TMP_DIR}/admin-page.out" GET "${BASE_URL}/appcheck/admin/" "${ADMIN_
 assert_status "200" "${HTTP_STATUS}" "admin dashboard"
 echo "admin dashboard: HTTP 200"
 
-run_curl "${TMP_DIR}/admin-metrics.out" GET "${BASE_URL}/appcheck/_admin/api/v1/request-metrics" "${ADMIN_HEADERS[@]}"
-assert_status "200" "${HTTP_STATUS}" "admin metrics"
-echo "admin metrics: HTTP 200"
+wait_for_request_metrics
 
 run_curl "${TMP_DIR}/admin-audit.out" GET "${BASE_URL}/appcheck/_admin/api/v1/audit-events?limit=20" "${ADMIN_HEADERS[@]}"
 assert_status "200" "${HTTP_STATUS}" "admin audit"
+assert_audit_events_nonzero "${TMP_DIR}/admin-audit.out"
 assert_audit_sanitized "${TMP_DIR}/admin-audit.out"
 echo "admin audit sanitization: OK"

--- a/scripts/k6-audit-load-matrix.sh
+++ b/scripts/k6-audit-load-matrix.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-${ROOT_DIR}/dev/.env}"
+K6_IMAGE="${K6_IMAGE:-grafana/k6:0.54.0}"
+K6_DURATION="${K6_DURATION:-30s}"
+TRAEFIK_PORT="${TRAEFIK_PORT:-39080}"
+TRAEFIK_DASHBOARD_PORT="${TRAEFIK_DASHBOARD_PORT:-39088}"
+RESULT_ROOT="${RESULT_ROOT:-${ROOT_DIR}/.tmp/k6-audit-load/$(date -u +%Y%m%dT%H%M%SZ)}"
+
+BASE_COMPOSE=(-f "${ROOT_DIR}/dev/docker-compose.yml" -f "${ROOT_DIR}/dev/docker-compose.e2e.yml")
+CSV_FILE="${RESULT_ROOT}/summary.csv"
+CURRENT_COMPOSE=()
+
+mkdir -p "${RESULT_ROOT}"
+cp -n "${ROOT_DIR}/dev/.env.example" "${ENV_FILE}" || true
+
+cleanup() {
+  if [[ "${KEEP_LOAD_STACK:-false}" == "true" ]]; then
+    return
+  fi
+  if [[ ${#CURRENT_COMPOSE[@]} -gt 0 ]]; then
+    docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+write_csv_header() {
+  cat > "${CSV_FILE}" <<'CSV'
+case,db,audit_async,mode,rate,duration,iterations,checks_rate,http_req_failed_rate,http_req_duration_avg_ms,http_req_duration_p90_ms,http_req_duration_p95_ms,http_req_duration_p99_ms,http_req_duration_max_ms
+CSV
+}
+
+compose_db_file() {
+  case "$1" in
+    postgres) printf "%s\n" "${ROOT_DIR}/dev/docker-compose.pg.yml" ;;
+    mariadb) printf "%s\n" "${ROOT_DIR}/dev/docker-compose.mariadb.yml" ;;
+    *) echo "unsupported db $1" >&2; exit 1 ;;
+  esac
+}
+
+rates_for_case() {
+  local mode="$1"
+  local async="$2"
+  if [[ -n "${LOAD_RATES:-}" ]]; then
+    printf "%s\n" "${LOAD_RATES//,/ }"
+    return
+  fi
+  if [[ "${mode}" == "exchange-valid" ]]; then
+    printf "%s\n" "100 300 500"
+  elif [[ "${async}" == "true" ]]; then
+    printf "%s\n" "500 1000 2000"
+  else
+    printf "%s\n" "100 500 1000"
+  fi
+}
+
+wait_for_ready() {
+  local url="http://127.0.0.1:${TRAEFIK_PORT}/readyz"
+  local attempt
+  for attempt in $(seq 1 90); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "service did not become ready at ${url}" >&2
+  docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" ps >&2 || true
+  docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" logs --no-color --tail=200 >&2 || true
+  exit 1
+}
+
+start_stack() {
+  local db="$1"
+  local async="$2"
+  local case_dir="$3"
+  local override="${case_dir}/audit-async.override.yml"
+  cat > "${override}" <<YAML
+services:
+  turnstile-appcheck-gateway:
+    environment:
+      AUDIT_ASYNC_ENABLED: "${async}"
+YAML
+
+  CURRENT_COMPOSE=("${BASE_COMPOSE[@]}" -f "$(compose_db_file "${db}")" -f "${override}")
+  docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+  TRAEFIK_PORT="${TRAEFIK_PORT}" TRAEFIK_DASHBOARD_PORT="${TRAEFIK_DASHBOARD_PORT}" \
+    docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" up -d --build
+  wait_for_ready
+}
+
+append_summary_csv() {
+  local summary="$1"
+  local case_id="$2"
+  local db="$3"
+  local async="$4"
+  local mode="$5"
+  local rate="$6"
+  python3 - "$summary" "$CSV_FILE" "$case_id" "$db" "$async" "$mode" "$rate" "$K6_DURATION" <<'PY'
+import csv
+import json
+import sys
+
+summary_path, csv_path, case_id, db, async_enabled, mode, rate, duration = sys.argv[1:]
+with open(summary_path, encoding="utf-8") as fh:
+    data = json.load(fh)
+metrics = data.get("metrics", {})
+
+def metric_value(name, key, default=0):
+    metric = metrics.get(name, {})
+    if key in metric:
+        return metric.get(key, default)
+    return metric.get("values", {}).get(key, default)
+
+row = {
+    "case": case_id,
+    "db": db,
+    "audit_async": async_enabled,
+    "mode": mode,
+    "rate": rate,
+    "duration": duration,
+    "iterations": metric_value("iterations", "count"),
+    "checks_rate": metric_value("checks", "rate", metric_value("checks", "value")),
+    "http_req_failed_rate": metric_value("http_req_failed", "rate", metric_value("http_req_failed", "value")),
+    "http_req_duration_avg_ms": metric_value("http_req_duration", "avg"),
+    "http_req_duration_p90_ms": metric_value("http_req_duration", "p(90)"),
+    "http_req_duration_p95_ms": metric_value("http_req_duration", "p(95)"),
+    "http_req_duration_p99_ms": metric_value("http_req_duration", "p(99)"),
+    "http_req_duration_max_ms": metric_value("http_req_duration", "max"),
+}
+with open(csv_path, "a", encoding="utf-8", newline="") as fh:
+    writer = csv.DictWriter(fh, fieldnames=list(row))
+    writer.writerow(row)
+PY
+}
+
+run_k6() {
+  local case_id="$1"
+  local db="$2"
+  local async="$3"
+  local mode="$4"
+  local rate="$5"
+  local case_dir="$6"
+  local run_dir="${case_dir}/${mode}-${rate}"
+  mkdir -p "${run_dir}"
+  chmod 0777 "${run_dir}"
+  echo "k6 case=${case_id} db=${db} async=${async} mode=${mode} rate=${rate} duration=${K6_DURATION}"
+  set +e
+  docker run --rm --network appcheck-devnet \
+    -v "${ROOT_DIR}:/src:ro" \
+    -v "${run_dir}:/results" \
+    -e BASE_URL="http://traefik" \
+    -e MODE="${mode}" \
+    -e RATE="${rate}" \
+    -e DURATION="${K6_DURATION}" \
+    -e PRE_ALLOCATED_VUS="${PRE_ALLOCATED_VUS:-}" \
+    -e MAX_VUS="${MAX_VUS:-}" \
+    "${K6_IMAGE}" run --summary-export "/results/summary.json" "/src/scripts/k6/audit-load.js" \
+    2>&1 | tee "${run_dir}/k6.log"
+  local status=${PIPESTATUS[0]}
+  set -e
+  if [[ -f "${run_dir}/summary.json" ]]; then
+    append_summary_csv "${run_dir}/summary.json" "${case_id}" "${db}" "${async}" "${mode}" "${rate}"
+  fi
+  if [[ ${status} -ne 0 ]]; then
+    echo "k6 failed for case=${case_id} db=${db} async=${async} mode=${mode} rate=${rate}" >&2
+    return "${status}"
+  fi
+}
+
+run_case() {
+  local case_id="$1"
+  local db="$2"
+  local async="$3"
+  local mode="$4"
+  local case_dir="${RESULT_ROOT}/case-${case_id}-${db}-async-${async}-${mode}"
+  mkdir -p "${case_dir}"
+  start_stack "${db}" "${async}" "${case_dir}"
+  local rate
+  for rate in $(rates_for_case "${mode}" "${async}"); do
+    run_k6 "${case_id}" "${db}" "${async}" "${mode}" "${rate}" "${case_dir}"
+  done
+  docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" logs --no-color --tail=300 > "${case_dir}/compose.log" 2>/dev/null || true
+  docker compose --env-file "${ENV_FILE}" "${CURRENT_COMPOSE[@]}" down -v --remove-orphans
+  CURRENT_COMPOSE=()
+}
+
+should_run_case() {
+  local case_id="$1"
+  if [[ -z "${LOAD_CASES:-}" ]]; then
+    return 0
+  fi
+  case ",${LOAD_CASES}," in
+    *",${case_id},"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+maybe_run_case() {
+  local case_id="$1"
+  shift
+  if should_run_case "${case_id}"; then
+    run_case "${case_id}" "$@"
+  fi
+}
+
+main() {
+  write_csv_header
+  maybe_run_case 1 postgres false verify-missing
+  maybe_run_case 2 mariadb false verify-missing
+  maybe_run_case 3 postgres true verify-missing
+  maybe_run_case 4 mariadb true verify-missing
+  maybe_run_case 5 postgres true exchange-valid
+  maybe_run_case 6 mariadb true exchange-valid
+  echo "k6 audit load results: ${RESULT_ROOT}"
+  echo "summary csv: ${CSV_FILE}"
+}
+
+main "$@"

--- a/scripts/k6/audit-load.js
+++ b/scripts/k6/audit-load.js
@@ -1,0 +1,70 @@
+import http from "k6/http";
+import { check } from "k6";
+
+const mode = (__ENV.MODE || "verify-missing").trim();
+const rate = Number(__ENV.RATE || "100");
+const duration = __ENV.DURATION || "30s";
+const baseURL = (__ENV.BASE_URL || "http://traefik").replace(/\/+$/, "");
+const preAllocatedVUs = Number(__ENV.PRE_ALLOCATED_VUS || Math.max(50, Math.ceil(rate / 10)));
+const maxVUs = Number(__ENV.MAX_VUS || Math.max(preAllocatedVUs * 2, Math.ceil(rate / 2)));
+
+if (!Number.isFinite(rate) || rate <= 0) {
+  throw new Error(`RATE must be a positive number, got ${__ENV.RATE}`);
+}
+
+if (mode === "verify-missing") {
+  http.setResponseCallback(http.expectedStatuses(401));
+} else if (mode === "exchange-valid") {
+  http.setResponseCallback(http.expectedStatuses(200));
+} else {
+  throw new Error(`unsupported MODE ${mode}`);
+}
+
+export const options = {
+  scenarios: {
+    load: {
+      executor: "constant-arrival-rate",
+      rate,
+      timeUnit: "1s",
+      duration,
+      preAllocatedVUs,
+      maxVUs,
+    },
+  },
+  tags: {
+    mode,
+    rate: String(rate),
+  },
+  summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export default function () {
+  if (mode === "verify-missing") {
+    const res = http.get(`${baseURL}/appcheck/api/v1/verify`, {
+      tags: { endpoint: "verify-missing" },
+    });
+    check(res, {
+      "verify missing returns 401": (r) => r.status === 401,
+    });
+    return;
+  }
+
+  const payload = JSON.stringify({
+    turnstileToken: "e2e-turnstile-pass",
+    limitedUse: false,
+  });
+  const res = http.post(`${baseURL}/appcheck/api/v1/exchange`, payload, {
+    headers: { "Content-Type": "application/json" },
+    tags: { endpoint: "exchange-valid" },
+  });
+  check(res, {
+    "exchange valid returns 200": (r) => r.status === 200,
+    "exchange valid has token": (r) => {
+      try {
+        return Boolean(r.json("token"));
+      } catch {
+        return false;
+      }
+    },
+  });
+}


### PR DESCRIPTION
### Summary
- English
  - Makes audit flushing retry-safe and adds PostgreSQL/MariaDB compose e2e plus k6 load coverage for audit storage.
- Japanese
  - audit flush を retry-safe にし、PostgreSQL/MariaDB の compose e2e と k6 audit storage load coverage を追加します。

### Why
- English
  - Event inserts and metric rollups need to be persisted consistently under retries, and DB backend behavior should be covered with repeatable integration and load tests.
- Japanese
  - retry 時に event insert と metric rollup を一貫して永続化する必要があり、DB backend ごとの挙動を再現可能な integration/load test で確認できるようにします。

- closes #22 