### PR TITLE
Handle CORS for exchange endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Configuration is read from environment variables. Use [.env.example](.env.exampl
 | `RATE_LIMIT_REQUESTS` | optional | `120` | requests per rate limit window |
 | `RATE_LIMIT_WINDOW` | optional | `1m` | rate limit window |
 
-Public `/exchange` requests use strict JSON decoding with unknown fields rejected and a capped request body. `turnstileToken` is required and length-limited. Public `/exchange` and `/verify` requests are protected by a lightweight in-memory rate limiter. In multi-instance deployments, each instance keeps its own counters.
+Public `/exchange` requests use strict JSON decoding with unknown fields rejected and a capped request body. `turnstileToken` is required and length-limited. When `Origin` is present, `/exchange` responds to allowed origins with CORS headers and `OPTIONS` preflight handling based on `ALLOWED_EXCHANGE_ORIGINS`. Public `/exchange` and `/verify` requests are protected by a lightweight in-memory rate limiter. In multi-instance deployments, each instance keeps its own counters.
 
 `/exchange` does not implement idempotency. Turnstile response tokens and App Check tokens are short-lived, and replaying the same token-exchange payload can conflict with the external validation flow. Failed client attempts should obtain a fresh Turnstile token before retrying.
 
@@ -542,7 +542,7 @@ docs/images
 | `RATE_LIMIT_REQUESTS` | 任意 | `120` | rate limit window あたりの request 上限 |
 | `RATE_LIMIT_WINDOW` | 任意 | `1m` | rate limit window |
 
-public `/exchange` request は strict JSON decoding を使い、unknown field を拒否し、request body size を制限します。`turnstileToken` は必須で length limit があります。public `/exchange` と `/verify` は軽量な in-memory rate limiter で保護されます。multi-instance 構成では instance ごとに counter を持ちます。
+public `/exchange` request は strict JSON decoding を使い、unknown field を拒否し、request body size を制限します。`turnstileToken` は必須で length limit があります。`Origin` がある場合、`/exchange` は `ALLOWED_EXCHANGE_ORIGINS` に基づいて allowed origin に CORS header と `OPTIONS` preflight 応答を返します。public `/exchange` と `/verify` は軽量な in-memory rate limiter で保護されます。multi-instance 構成では instance ごとに counter を持ちます。
 
 `/exchange` は idempotency を実装していません。Turnstile response token と App Check token は短命で、同じ token-exchange payload の replay は外部検証 flow と相性がよくありません。失敗時は client が新しい Turnstile token を取得して再試行してください。
 

--- a/internal/httpserver/path_test.go
+++ b/internal/httpserver/path_test.go
@@ -1,9 +1,11 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -69,6 +71,7 @@ func TestNewRouterRoutes(t *testing.T) {
 	}
 
 	for _, required := range []string{
+		"OPTIONS /appcheck/api/v1/exchange",
 		"POST /appcheck/api/v1/exchange",
 		"GET /healthz",
 		"GET /readyz",
@@ -76,6 +79,101 @@ func TestNewRouterRoutes(t *testing.T) {
 		if !routes[required] {
 			t.Fatalf("missing route: %s", required)
 		}
+	}
+}
+
+func TestNewRouterExchangePreflightRespondsWithCORSHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		AppCheckSubpath:        "/appcheck",
+		HealthPath:             "/healthz",
+		ReadyPath:              "/readyz",
+		AllowedExchangeOrigins: []string{"https://example.com"},
+	}
+
+	exchangeHandler := &handlers.ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: stubTurnstileVerifier{},
+		Exchanger:         stubExchanger{},
+		OriginAllowed:     cfg.IsExchangeOriginAllowed,
+	}
+	verifyHandler := &handlers.VerifyHandler{
+		Logger:        slog.Default(),
+		Verifier:      stubVerifyVerifier{},
+		HeaderName:    "X-Firebase-AppCheck",
+		SuccessStatus: http.StatusNoContent,
+		FailureStatus: http.StatusUnauthorized,
+	}
+
+	r, err := NewRouter(cfg, slog.Default(), exchangeHandler, verifyHandler, health.NewHandler())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodOptions, "/appcheck/api/v1/exchange", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q; want %q", got, "https://example.com")
+	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); got != "POST, OPTIONS" {
+		t.Fatalf("Access-Control-Allow-Methods = %q; want %q", got, "POST, OPTIONS")
+	}
+	if got := w.Header().Get("Access-Control-Allow-Headers"); got != "content-type" {
+		t.Fatalf("Access-Control-Allow-Headers = %q; want %q", got, "content-type")
+	}
+}
+
+func TestNewRouterExchangePostRespondsWithCORSHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		AppCheckSubpath:        "/appcheck",
+		HealthPath:             "/healthz",
+		ReadyPath:              "/readyz",
+		AllowedExchangeOrigins: []string{"https://example.com"},
+	}
+
+	exchangeHandler := &handlers.ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: stubTurnstileVerifier{},
+		Exchanger:         stubExchanger{},
+		OriginAllowed:     cfg.IsExchangeOriginAllowed,
+	}
+	verifyHandler := &handlers.VerifyHandler{
+		Logger:        slog.Default(),
+		Verifier:      stubVerifyVerifier{},
+		HeaderName:    "X-Firebase-AppCheck",
+		SuccessStatus: http.StatusNoContent,
+		FailureStatus: http.StatusUnauthorized,
+	}
+
+	r, err := NewRouter(cfg, slog.Default(), exchangeHandler, verifyHandler, health.NewHandler())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/appcheck/api/v1/exchange", bytes.NewBufferString(`{"turnstileToken":"token"}`))
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q; want %q", got, "https://example.com")
 	}
 }
 

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -49,8 +49,14 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, exchangeHandler *handler
 	}
 
 	api := r.Group(cfg.AppCheckSubpath)
-	public := api.Group("", middleware.NewRateLimiter(cfg.RateLimit, logger, recorder))
-	public.POST("/api/v1/exchange", exchangeHandler.Handle)
+	rateLimiter := middleware.NewRateLimiter(cfg.RateLimit, logger, recorder)
+	exchange := api.Group("/api/v1/exchange", middleware.ExchangeCORS(cfg.IsExchangeOriginAllowed))
+	exchange.OPTIONS("", func(c *gin.Context) {
+		c.Status(204)
+	})
+	exchange.POST("", rateLimiter, exchangeHandler.Handle)
+
+	public := api.Group("", rateLimiter)
 	public.Any("/api/v1/verify", verifyHandler.Handle)
 	admin.Register(api, cfg, logger, recorder)
 

--- a/internal/middleware/exchange_cors.go
+++ b/internal/middleware/exchange_cors.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ExchangeCORS handles browser CORS for the public /exchange endpoint.
+func ExchangeCORS(originAllowed func(string) bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		origin := strings.TrimSpace(c.GetHeader("Origin"))
+		if origin == "" {
+			c.Next()
+			return
+		}
+
+		if originAllowed != nil && !originAllowed(origin) {
+			if c.Request.Method == http.MethodOptions {
+				c.AbortWithStatus(http.StatusForbidden)
+				return
+			}
+			c.Next()
+			return
+		}
+
+		header := c.Writer.Header()
+		addVaryHeader(header, "Origin")
+		header.Set("Access-Control-Allow-Origin", origin)
+		header.Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+
+		requestHeaders := strings.TrimSpace(c.GetHeader("Access-Control-Request-Headers"))
+		if requestHeaders == "" {
+			requestHeaders = "Content-Type"
+		} else {
+			addVaryHeader(header, "Access-Control-Request-Headers")
+		}
+		header.Set("Access-Control-Allow-Headers", requestHeaders)
+
+		if c.Request.Method == http.MethodOptions {
+			requestMethod := strings.TrimSpace(c.GetHeader("Access-Control-Request-Method"))
+			if requestMethod != "" && !strings.EqualFold(requestMethod, http.MethodPost) {
+				c.AbortWithStatus(http.StatusMethodNotAllowed)
+				return
+			}
+
+			addVaryHeader(header, "Access-Control-Request-Method")
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func addVaryHeader(header http.Header, value string) {
+	for _, existing := range header.Values("Vary") {
+		for _, part := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	header.Add("Vary", value)
+}


### PR DESCRIPTION
### Summary
- English
  - Add `/exchange` CORS middleware, explicit `OPTIONS` handling, and router-level coverage for allowed origins.
- Japanese
  - `/exchange` 向けの CORS middleware、明示的な `OPTIONS` handling、allowed origin を対象にした router-level coverage を追加する。
### Why
- English
  - Allowed origins need proper browser preflight support and CORS response headers, not only origin allow/deny checks.
- Japanese
  - allowed origin には origin の allow/deny 判定だけでなく、browser preflight support と CORS response header が必要である。

Closes #24