### PR TITLE
Handle verify preflight for forwardAuth CORS

### DIFF
--- a/internal/httpserver/path_test.go
+++ b/internal/httpserver/path_test.go
@@ -177,6 +177,149 @@ func TestNewRouterExchangePostRespondsWithCORSHeaders(t *testing.T) {
 	}
 }
 
+func TestNewRouterVerifyPreflightRespondsWithCORSHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		AppCheckSubpath:        "/appcheck",
+		HealthPath:             "/healthz",
+		ReadyPath:              "/readyz",
+		AllowedExchangeOrigins: []string{"https://example.com"},
+		VerifyHeaderName:       "X-Firebase-AppCheck",
+	}
+
+	exchangeHandler := &handlers.ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: stubTurnstileVerifier{},
+		Exchanger:         stubExchanger{},
+		OriginAllowed:     cfg.IsExchangeOriginAllowed,
+	}
+	verifyHandler := &handlers.VerifyHandler{
+		Logger:        slog.Default(),
+		Verifier:      stubVerifyVerifier{},
+		HeaderName:    "X-Firebase-AppCheck",
+		SuccessStatus: http.StatusNoContent,
+		FailureStatus: http.StatusUnauthorized,
+	}
+
+	r, err := NewRouter(cfg, slog.Default(), exchangeHandler, verifyHandler, health.NewHandler())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodOptions, "/appcheck/api/v1/verify", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type,x-firebase-appcheck")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q; want %q", got, "https://example.com")
+	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); got != "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS" {
+		t.Fatalf("Access-Control-Allow-Methods = %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Headers"); got != "content-type,x-firebase-appcheck" {
+		t.Fatalf("Access-Control-Allow-Headers = %q; want %q", got, "content-type,x-firebase-appcheck")
+	}
+}
+
+func TestNewRouterVerifyForwardAuthPreflightRespondsWithCORSHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		AppCheckSubpath:        "/appcheck",
+		HealthPath:             "/healthz",
+		ReadyPath:              "/readyz",
+		AllowedExchangeOrigins: []string{"https://example.com"},
+		VerifyHeaderName:       "X-Firebase-AppCheck",
+	}
+
+	exchangeHandler := &handlers.ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: stubTurnstileVerifier{},
+		Exchanger:         stubExchanger{},
+		OriginAllowed:     cfg.IsExchangeOriginAllowed,
+	}
+	verifyHandler := &handlers.VerifyHandler{
+		Logger:        slog.Default(),
+		Verifier:      stubVerifyVerifier{},
+		HeaderName:    "X-Firebase-AppCheck",
+		SuccessStatus: http.StatusNoContent,
+		FailureStatus: http.StatusUnauthorized,
+	}
+
+	r, err := NewRouter(cfg, slog.Default(), exchangeHandler, verifyHandler, health.NewHandler())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/appcheck/api/v1/verify", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "content-type,x-firebase-appcheck")
+	req.Header.Set("X-Forwarded-Method", http.MethodOptions)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q; want %q", got, "https://example.com")
+	}
+}
+
+func TestNewRouterVerifyGetWithoutTokenStillRequiresAppCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		AppCheckSubpath:        "/appcheck",
+		HealthPath:             "/healthz",
+		ReadyPath:              "/readyz",
+		AllowedExchangeOrigins: []string{"https://example.com"},
+		VerifyHeaderName:       "X-Firebase-AppCheck",
+	}
+
+	exchangeHandler := &handlers.ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: stubTurnstileVerifier{},
+		Exchanger:         stubExchanger{},
+		OriginAllowed:     cfg.IsExchangeOriginAllowed,
+	}
+	verifyHandler := &handlers.VerifyHandler{
+		Logger:        slog.Default(),
+		Verifier:      stubVerifyVerifier{},
+		HeaderName:    "X-Firebase-AppCheck",
+		SuccessStatus: http.StatusNoContent,
+		FailureStatus: http.StatusUnauthorized,
+	}
+
+	r, err := NewRouter(cfg, slog.Default(), exchangeHandler, verifyHandler, health.NewHandler())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/appcheck/api/v1/verify", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q; want %q", got, "https://example.com")
+	}
+}
+
 type stubTurnstileVerifier struct{}
 
 func (stubTurnstileVerifier) Verify(_ context.Context, _ turnstile.VerifyRequest) (*turnstile.VerifyResponse, error) {

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -56,8 +56,8 @@ func NewRouter(cfg *config.Config, logger *slog.Logger, exchangeHandler *handler
 	})
 	exchange.POST("", rateLimiter, exchangeHandler.Handle)
 
-	public := api.Group("", rateLimiter)
-	public.Any("/api/v1/verify", verifyHandler.Handle)
+	verify := api.Group("/api/v1/verify", middleware.VerifyCORS(cfg.IsExchangeOriginAllowed, cfg.VerifyHeaderName))
+	verify.Any("", rateLimiter, verifyHandler.Handle)
 	admin.Register(api, cfg, logger, recorder)
 
 	return r, nil

--- a/internal/middleware/exchange_cors.go
+++ b/internal/middleware/exchange_cors.go
@@ -7,17 +7,69 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+var verifyCORSMethods = []string{
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+	http.MethodOptions,
+}
+
 // ExchangeCORS handles browser CORS for the public /exchange endpoint.
 func ExchangeCORS(originAllowed func(string) bool) gin.HandlerFunc {
+	return endpointCORS(originAllowed, corsOptions{
+		allowMethods:            []string{http.MethodPost, http.MethodOptions},
+		defaultAllowHeaders:     "Content-Type",
+		handlePreflight:         true,
+		allowForwardedPreflight: false,
+		validateRequestedMethod: true,
+		requirePreflightHeaders: false,
+	})
+}
+
+// VerifyCORS handles browser preflight auth checks for the forwardAuth /verify endpoint.
+func VerifyCORS(originAllowed func(string) bool, verifyHeaderName string) gin.HandlerFunc {
+	defaultAllowHeaders := "Content-Type, X-Firebase-AppCheck"
+	if strings.TrimSpace(verifyHeaderName) != "" {
+		defaultAllowHeaders = "Content-Type, " + strings.TrimSpace(verifyHeaderName)
+	}
+
+	return endpointCORS(originAllowed, corsOptions{
+		allowMethods:            verifyCORSMethods,
+		defaultAllowHeaders:     defaultAllowHeaders,
+		handlePreflight:         true,
+		allowForwardedPreflight: true,
+		validateRequestedMethod: true,
+		requirePreflightHeaders: true,
+	})
+}
+
+type corsOptions struct {
+	allowMethods            []string
+	defaultAllowHeaders     string
+	handlePreflight         bool
+	allowForwardedPreflight bool
+	validateRequestedMethod bool
+	requirePreflightHeaders bool
+}
+
+func endpointCORS(originAllowed func(string) bool, opts corsOptions) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		origin := strings.TrimSpace(c.GetHeader("Origin"))
+		preflight := isCORSPreflight(c, opts)
 		if origin == "" {
+			if preflight {
+				c.AbortWithStatus(http.StatusNoContent)
+				return
+			}
 			c.Next()
 			return
 		}
 
 		if originAllowed != nil && !originAllowed(origin) {
-			if c.Request.Method == http.MethodOptions {
+			if preflight {
 				c.AbortWithStatus(http.StatusForbidden)
 				return
 			}
@@ -28,19 +80,22 @@ func ExchangeCORS(originAllowed func(string) bool) gin.HandlerFunc {
 		header := c.Writer.Header()
 		addVaryHeader(header, "Origin")
 		header.Set("Access-Control-Allow-Origin", origin)
-		header.Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		header.Set("Access-Control-Allow-Methods", strings.Join(opts.allowMethods, ", "))
 
 		requestHeaders := strings.TrimSpace(c.GetHeader("Access-Control-Request-Headers"))
 		if requestHeaders == "" {
-			requestHeaders = "Content-Type"
+			requestHeaders = opts.defaultAllowHeaders
 		} else {
 			addVaryHeader(header, "Access-Control-Request-Headers")
 		}
 		header.Set("Access-Control-Allow-Headers", requestHeaders)
 
-		if c.Request.Method == http.MethodOptions {
+		if preflight {
 			requestMethod := strings.TrimSpace(c.GetHeader("Access-Control-Request-Method"))
-			if requestMethod != "" && !strings.EqualFold(requestMethod, http.MethodPost) {
+			if requestMethod == "" {
+				requestMethod = strings.TrimSpace(c.GetHeader("X-Forwarded-Method"))
+			}
+			if opts.validateRequestedMethod && requestMethod != "" && !methodAllowed(requestMethod, opts.allowMethods) {
 				c.AbortWithStatus(http.StatusMethodNotAllowed)
 				return
 			}
@@ -52,6 +107,31 @@ func ExchangeCORS(originAllowed func(string) bool) gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+func isCORSPreflight(c *gin.Context, opts corsOptions) bool {
+	if !opts.handlePreflight {
+		return false
+	}
+	if c.Request.Method == http.MethodOptions {
+		return true
+	}
+	if !opts.allowForwardedPreflight || !strings.EqualFold(strings.TrimSpace(c.GetHeader("X-Forwarded-Method")), http.MethodOptions) {
+		return false
+	}
+	if !opts.requirePreflightHeaders {
+		return true
+	}
+	return strings.TrimSpace(c.GetHeader("Origin")) != "" && strings.TrimSpace(c.GetHeader("Access-Control-Request-Method")) != ""
+}
+
+func methodAllowed(method string, allowed []string) bool {
+	for _, candidate := range allowed {
+		if strings.EqualFold(strings.TrimSpace(method), candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func addVaryHeader(header http.Header, value string) {


### PR DESCRIPTION
### Summary
- English
  - Add verify endpoint CORS/preflight handling for direct browser OPTIONS requests and Traefik forwardAuth preflight requests.
- Japanese
  - browser からの直接 OPTIONS request と Traefik forwardAuth 経由の preflight request に対応する verify endpoint の CORS/preflight 処理を追加します。
### Why
- English
  - Cross-origin requests to protected APIs can fail before reaching the upstream because preflight requests do not carry the App Check token and were rejected by `/verify`.
- Japanese
  - 保護対象 API への cross-origin request では preflight に App Check token が載らず、`/verify` で拒否されることで upstream 到達前に失敗していました。

Closes #26
