### PR TITLE
Treat forwarded OPTIONS as verify preflight

### DIFF
--- a/internal/httpserver/path_test.go
+++ b/internal/httpserver/path_test.go
@@ -276,6 +276,55 @@ func TestNewRouterVerifyForwardAuthPreflightRespondsWithCORSHeaders(t *testing.T
 	}
 }
 
+func TestNewRouterVerifyForwardAuthPreflightWithoutAccessControlRequestHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		AppCheckSubpath:        "/appcheck",
+		HealthPath:             "/healthz",
+		ReadyPath:              "/readyz",
+		AllowedExchangeOrigins: []string{"https://example.com"},
+		VerifyHeaderName:       "X-Firebase-AppCheck",
+	}
+
+	exchangeHandler := &handlers.ExchangeHandler{
+		Logger:            slog.Default(),
+		Timeout:           context.WithCancel,
+		TurnstileVerifier: stubTurnstileVerifier{},
+		Exchanger:         stubExchanger{},
+		OriginAllowed:     cfg.IsExchangeOriginAllowed,
+	}
+	verifyHandler := &handlers.VerifyHandler{
+		Logger:        slog.Default(),
+		Verifier:      stubVerifyVerifier{},
+		HeaderName:    "X-Firebase-AppCheck",
+		SuccessStatus: http.StatusNoContent,
+		FailureStatus: http.StatusUnauthorized,
+	}
+
+	r, err := NewRouter(cfg, slog.Default(), exchangeHandler, verifyHandler, health.NewHandler())
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/appcheck/api/v1/verify", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("X-Forwarded-Method", http.MethodOptions)
+	req.Header.Set("X-Forwarded-Uri", "/mx-api/api/v1/validate")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q; want %q", got, "https://example.com")
+	}
+	if got := w.Header().Get("Access-Control-Allow-Headers"); got != "Content-Type, X-Firebase-AppCheck" {
+		t.Fatalf("Access-Control-Allow-Headers = %q; want %q", got, "Content-Type, X-Firebase-AppCheck")
+	}
+}
+
 func TestNewRouterVerifyGetWithoutTokenStillRequiresAppCheck(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{

--- a/internal/middleware/exchange_cors.go
+++ b/internal/middleware/exchange_cors.go
@@ -42,7 +42,7 @@ func VerifyCORS(originAllowed func(string) bool, verifyHeaderName string) gin.Ha
 		handlePreflight:         true,
 		allowForwardedPreflight: true,
 		validateRequestedMethod: true,
-		requirePreflightHeaders: true,
+		requirePreflightHeaders: false,
 	})
 }
 


### PR DESCRIPTION
### Summary
- English
  - Treat Traefik forwardAuth subrequests with `X-Forwarded-Method: OPTIONS` as verify preflight even when `Access-Control-Request-*` headers are absent.
- Japanese
  - `Access-Control-Request-*` header が無い場合でも、Traefik forwardAuth subrequest の `X-Forwarded-Method: OPTIONS` を verify preflight として扱います。
### Why
- English
  - Production Traefik can call `/verify` as `GET` for browser preflight auth checks and only preserve the original method in `X-Forwarded-Method`; requiring `Access-Control-Request-Method` caused those requests to fall through to App Check token verification and fail with `401`.
- Japanese
  - 本番 Traefik では browser preflight の auth check が `/verify` へ `GET` として到達し、元 method だけが `X-Forwarded-Method` に残る場合があります。`Access-Control-Request-Method` を必須にしたことで App Check token 検証に落ち、`401` になっていました。

Closes #26
