### PR TITLE
Add Traefik CORS Helm e2e coverage

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -13,6 +13,7 @@ on:
       - "cmd/**"
       - "scripts/helm-e2e-kind.sh"
       - "scripts/e2e-smoke-mock.sh"
+      - "scripts/e2e-traefik-cors.sh"
       - "Makefile"
       - ".github/workflows/helm-e2e.yml"
 

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ audit-load-k6:
 	./scripts/k6-audit-load-matrix.sh
 
 e2e-kind-mock:
-	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh
+	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-traefik-cors.sh
 	./scripts/helm-e2e-kind.sh
 
 e2e-kind-keep:
-	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh
+	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-traefik-cors.sh
 	KEEP_CLUSTER=true ./scripts/helm-e2e-kind.sh
 
 e2e-kind-clean:

--- a/docs/e2e-and-release.md
+++ b/docs/e2e-and-release.md
@@ -24,6 +24,7 @@ PostgreSQL and MariaDB audit storage variants add `dev/docker-compose.pg.yml` or
 For k6 audit storage load tests, see [Load Testing](load-testing.md).
 
 `e2e-kind-mock` uses a repository-local kubeconfig under `.tmp/` and never targets `~/.kube/config`.
+It installs Traefik in the kind cluster, routes all smoke checks through Traefik, and verifies protected-route CORS behavior for same-origin requests, allowed cross-origin preflight, allowed cross-origin requests, denied origins, and spoofed `X-Forwarded-Method` bypass attempts.
 
 Keep the kind cluster:
 
@@ -177,6 +178,7 @@ PostgreSQL / MariaDB の audit storage variant は `dev/docker-compose.pg.yml` �
 k6 による audit storage load test は [Load Testing](load-testing.md) を参照してください。
 
 `e2e-kind-mock` は `.tmp/` 配下の repo-local kubeconfig を使い、`~/.kube/config` は使いません。
+kind cluster 内に Traefik を install し、smoke check は Traefik 経由で実行します。protected route の CORS 挙動として same-origin request、allowed cross-origin preflight、allowed cross-origin request、denied origin、`X-Forwarded-Method` spoofing による bypass 試行を検証します。
 
 kind cluster を残す:
 

--- a/scripts/e2e-traefik-cors.sh
+++ b/scripts/e2e-traefik-cors.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_URL="${1:-}"
+if [[ -z "${BASE_URL}" ]]; then
+  echo "usage: $0 <base-url>" >&2
+  exit 1
+fi
+
+ALLOWED_ORIGIN="${ALLOWED_ORIGIN:-https://sinensis-lab.timelessbond.org}"
+DENIED_ORIGIN="${DENIED_ORIGIN:-https://evil.example}"
+PROTECTED_PATH="${PROTECTED_PATH:-/mx-api/api/v1/validate}"
+VERIFY_HEADER_NAME="${VERIFY_HEADER_NAME:-X-Firebase-AppCheck}"
+TMP_DIR="$(mktemp -d)"
+HTTP_STATUS=""
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+log() {
+  printf '%s\n' "$*"
+}
+
+run_curl() {
+  local label="$1"
+  local method="$2"
+  local path="$3"
+  shift 3
+
+  local safe_label
+  safe_label="$(printf '%s' "${label}" | tr -c 'A-Za-z0-9_.-' '_')"
+  local headers="${TMP_DIR}/${safe_label}.headers"
+  local body="${TMP_DIR}/${safe_label}.body"
+
+  HTTP_STATUS="$(curl -sS -D "${headers}" -o "${body}" -w "%{http_code}" -X "${method}" "${BASE_URL}${path}" "$@")"
+  log "${label}: ${method} ${path} -> HTTP ${HTTP_STATUS}"
+  sed -n '1,20p' "${headers}" | sed 's/^/  header: /'
+  if [[ -s "${body}" ]]; then
+    sed -n '1,20p' "${body}" | sed 's/^/  body: /'
+  fi
+  LAST_HEADERS="${headers}"
+  LAST_BODY="${body}"
+}
+
+assert_status() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${label}: expected HTTP ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_2xx() {
+  local actual="$1"
+  local label="$2"
+  if [[ ! "${actual}" =~ ^2 ]]; then
+    echo "${label}: expected HTTP 2xx, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_header_equals() {
+  local file="$1"
+  local header_name="$2"
+  local expected="$3"
+  local label="$4"
+  local actual
+  actual="$(awk -v name="${header_name}" 'BEGIN{IGNORECASE=1} index($0, name ":") == 1 {sub("^[^:]+:[[:space:]]*", ""); gsub("\r$", ""); print; exit}' "${file}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${label}: expected ${header_name}: ${expected}, got ${actual:-<missing>}" >&2
+    exit 1
+  fi
+}
+
+assert_header_contains() {
+  local file="$1"
+  local header_name="$2"
+  local expected_part="$3"
+  local label="$4"
+  local actual
+  actual="$(awk -v name="${header_name}" 'BEGIN{IGNORECASE=1} index($0, name ":") == 1 {sub("^[^:]+:[[:space:]]*", ""); gsub("\r$", ""); print; exit}' "${file}")"
+  local actual_lower="${actual,,}"
+  local expected_lower="${expected_part,,}"
+  if [[ "${actual_lower}" != *"${expected_lower}"* ]]; then
+    echo "${label}: expected ${header_name} to contain ${expected_part}, got ${actual:-<missing>}" >&2
+    exit 1
+  fi
+}
+
+assert_header_missing() {
+  local file="$1"
+  local header_name="$2"
+  local label="$3"
+  if awk -v name="${header_name}" 'BEGIN{IGNORECASE=1} index($0, name ":") == 1 {found=1} END{exit found ? 0 : 1}' "${file}"; then
+    echo "${label}: unexpected ${header_name} header" >&2
+    exit 1
+  fi
+}
+
+extract_json_field() {
+  local file="$1"
+  local field="$2"
+  python3 - "$file" "$field" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+value = data[sys.argv[2]]
+if isinstance(value, (dict, list)):
+    raise SystemExit(f"field {sys.argv[2]} must be scalar")
+print(value)
+PY
+}
+
+log "traefik cors e2e: base=${BASE_URL} protected=${PROTECTED_PATH} allowed_origin=${ALLOWED_ORIGIN}"
+
+cat > "${TMP_DIR}/exchange-valid.json" <<'JSON'
+{"turnstileToken":"e2e-turnstile-pass","limitedUse":false}
+JSON
+run_curl "cors.exchange-valid" POST "/appcheck/api/v1/exchange" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_DIR}/exchange-valid.json"
+assert_status "200" "${HTTP_STATUS}" "cors exchange valid"
+APP_CHECK_TOKEN="$(extract_json_field "${LAST_BODY}" token)"
+if [[ -z "${APP_CHECK_TOKEN}" ]]; then
+  echo "cors exchange valid: missing token" >&2
+  exit 1
+fi
+
+run_curl "same-origin.missing-token" GET "${PROTECTED_PATH}"
+assert_status "401" "${HTTP_STATUS}" "same-origin missing token"
+
+run_curl "same-origin.valid-token" GET "${PROTECTED_PATH}" \
+  -H "${VERIFY_HEADER_NAME}: ${APP_CHECK_TOKEN}"
+assert_2xx "${HTTP_STATUS}" "same-origin valid token"
+assert_header_missing "${LAST_HEADERS}" "Access-Control-Allow-Origin" "same-origin valid token"
+
+run_curl "cross-origin.allowed-preflight" OPTIONS "${PROTECTED_PATH}" \
+  -H "Origin: ${ALLOWED_ORIGIN}" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: content-type,x-firebase-appcheck"
+assert_2xx "${HTTP_STATUS}" "allowed cross-origin preflight"
+assert_header_equals "${LAST_HEADERS}" "Access-Control-Allow-Origin" "${ALLOWED_ORIGIN}" "allowed cross-origin preflight"
+assert_header_contains "${LAST_HEADERS}" "Access-Control-Allow-Methods" "POST" "allowed cross-origin preflight"
+assert_header_contains "${LAST_HEADERS}" "Access-Control-Allow-Headers" "X-Firebase-AppCheck" "allowed cross-origin preflight"
+
+run_curl "cross-origin.allowed-valid-token" POST "${PROTECTED_PATH}" \
+  -H "Origin: ${ALLOWED_ORIGIN}" \
+  -H "${VERIFY_HEADER_NAME}: ${APP_CHECK_TOKEN}" \
+  --data-binary '{"message":"ok"}'
+assert_2xx "${HTTP_STATUS}" "allowed cross-origin valid token"
+assert_header_equals "${LAST_HEADERS}" "Access-Control-Allow-Origin" "${ALLOWED_ORIGIN}" "allowed cross-origin valid token"
+
+run_curl "cross-origin.denied-preflight" OPTIONS "${PROTECTED_PATH}" \
+  -H "Origin: ${DENIED_ORIGIN}" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: content-type,x-firebase-appcheck"
+assert_header_missing "${LAST_HEADERS}" "Access-Control-Allow-Origin" "denied cross-origin preflight"
+
+run_curl "bypass.spoofed-forwarded-method" POST "${PROTECTED_PATH}" \
+  -H "Origin: ${ALLOWED_ORIGIN}" \
+  -H "X-Forwarded-Method: OPTIONS"
+assert_status "401" "${HTTP_STATUS}" "spoofed forwarded method bypass check"
+assert_header_equals "${LAST_HEADERS}" "Access-Control-Allow-Origin" "${ALLOWED_ORIGIN}" "spoofed forwarded method bypass check"
+if ! grep -q "APPCHECK_INVALID" "${LAST_BODY}"; then
+  echo "spoofed forwarded method bypass check: expected APPCHECK_INVALID body" >&2
+  exit 1
+fi
+
+log "traefik cors e2e: OK"

--- a/scripts/helm-e2e-kind.sh
+++ b/scripts/helm-e2e-kind.sh
@@ -7,6 +7,9 @@ NAMESPACE="${NAMESPACE:-appcheck-e2e}"
 RELEASE_NAME="${RELEASE_NAME:-turnstile-appcheck-gateway}"
 IMAGE_NAME="${IMAGE_NAME:-turnstile-appcheck-gateway:e2e}"
 LOCAL_PORT="${LOCAL_PORT:-18080}"
+TRAEFIK_NAMESPACE="${TRAEFIK_NAMESPACE:-traefik-e2e}"
+TRAEFIK_RELEASE_NAME="${TRAEFIK_RELEASE_NAME:-traefik}"
+ALLOWED_CORS_ORIGIN="${ALLOWED_CORS_ORIGIN:-https://sinensis-lab.timelessbond.org}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/.tmp/kind-${CLUSTER_NAME}.kubeconfig}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
 KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
@@ -27,11 +30,15 @@ mkdir -p "${ROOT_DIR}/.tmp"
 
 debug_dump() {
   echo "collecting kind debug output" >&2
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${TRAEFIK_NAMESPACE}" get all || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${TRAEFIK_NAMESPACE}" logs deploy/"${TRAEFIK_RELEASE_NAME}" || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get all || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get ingressroute,middleware || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get events --sort-by=.lastTimestamp || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" describe deploy "${RELEASE_NAME}" || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" logs deploy/"${RELEASE_NAME}" || true
   helm --kubeconfig "${KUBECONFIG_PATH}" status "${RELEASE_NAME}" -n "${NAMESPACE}" || true
+  helm --kubeconfig "${KUBECONFIG_PATH}" status "${TRAEFIK_RELEASE_NAME}" -n "${TRAEFIK_NAMESPACE}" || true
 }
 
 cleanup() {
@@ -80,6 +87,21 @@ kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
 kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace "${NAMESPACE}" --dry-run=client -o yaml | \
   kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
 
+kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace "${TRAEFIK_NAMESPACE}" --dry-run=client -o yaml | \
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
+
+if ! helm repo list | awk '{print $1}' | grep -Fxq traefik; then
+  helm repo add traefik https://traefik.github.io/charts
+fi
+helm repo update traefik
+
+helm --kubeconfig "${KUBECONFIG_PATH}" upgrade --install "${TRAEFIK_RELEASE_NAME}" traefik/traefik \
+  -n "${TRAEFIK_NAMESPACE}" \
+  --wait \
+  --timeout 5m \
+  --set deployment.replicas=1 \
+  --set service.type=ClusterIP
+
 IMAGE_REPOSITORY="${IMAGE_NAME%:*}"
 IMAGE_TAG="${IMAGE_NAME##*:}"
 if [[ "${IMAGE_REPOSITORY}" == "${IMAGE_TAG}" ]]; then
@@ -112,8 +134,119 @@ helm --kubeconfig "${KUBECONFIG_PATH}" upgrade --install "${RELEASE_NAME}" "${RO
 
 kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" rollout status deploy/"${RELEASE_NAME}" --timeout=5m
 
-kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" port-forward svc/"${RELEASE_NAME}" "${LOCAL_PORT}:80" \
+kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mx-api
+  labels:
+    app.kubernetes.io/name: mx-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mx-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mx-api
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami:v1.11
+          ports:
+            - containerPort: 80
+              name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mx-api
+spec:
+  selector:
+    app.kubernetes.io/name: mx-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mx-api-cors
+spec:
+  headers:
+    accessControlAllowOriginList:
+      - "${ALLOWED_CORS_ORIGIN}"
+    accessControlAllowMethods:
+      - GET
+      - POST
+      - OPTIONS
+    accessControlAllowHeaders:
+      - Content-Type
+      - X-Firebase-AppCheck
+    accessControlMaxAge: 86400
+    addVaryHeader: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-spoofed-forwarded-method
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Method: ""
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: appcheck-forward-auth
+spec:
+  forwardAuth:
+    address: http://${RELEASE_NAME}.${NAMESPACE}.svc.cluster.local/appcheck/api/v1/verify
+    trustForwardHeader: false
+    authResponseHeaders:
+      - X-AppCheck-Verified
+      - X-AppCheck-AppID
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: appcheck-gateway
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: PathPrefix(\`/appcheck\`) || Path(\`/healthz\`) || Path(\`/readyz\`)
+      services:
+        - name: ${RELEASE_NAME}
+          port: 80
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: mx-api
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: PathPrefix(\`/mx-api\`)
+      middlewares:
+        - name: mx-api-cors
+        - name: strip-spoofed-forwarded-method
+        - name: appcheck-forward-auth
+      services:
+        - name: mx-api
+          port: 80
+EOF
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" rollout status deploy/mx-api --timeout=5m
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${TRAEFIK_NAMESPACE}" port-forward svc/"${TRAEFIK_RELEASE_NAME}" "${LOCAL_PORT}:80" \
   > "${ROOT_DIR}/.tmp/kind-port-forward.log" 2>&1 &
 PORT_FORWARD_PID=$!
 
 "${ROOT_DIR}/scripts/e2e-smoke-mock.sh" "http://127.0.0.1:${LOCAL_PORT}"
+ALLOWED_ORIGIN="${ALLOWED_CORS_ORIGIN}" "${ROOT_DIR}/scripts/e2e-traefik-cors.sh" "http://127.0.0.1:${LOCAL_PORT}"


### PR DESCRIPTION
### Summary
- Installs Traefik in the kind Helm e2e path and routes smoke checks through Traefik instead of direct service port-forwarding.
- Adds a protected `mx-api` backend with Traefik CORS, header stripping, and forwardAuth middleware.
- Adds a dedicated Traefik CORS e2e script covering same-origin, allowed cross-origin preflight, allowed cross-origin authenticated requests, denied origins, and spoofed `X-Forwarded-Method` bypass attempts.

### Why
- The previous Helm e2e did not exercise the production-relevant Traefik forwardAuth path, so CORS preflight and forwarded-header bypass regressions were not caught.
- This makes the Helm e2e reproduce the deployment shape that exposed the production issue and asserts that allowed paths work while bypass attempts remain denied.

### Validation
- `KEEP_ON_FAILURE=false ./scripts/helm-e2e-kind.sh`
