### PR TITLE
Add kind audit database e2e variants

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -21,6 +21,16 @@ on:
 jobs:
   helm-e2e:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: mock-sqlite
+            target: e2e-kind-mock
+          - name: half-real-postgres
+            target: e2e-kind-half-real-pg
+          - name: half-real-mariadb
+            target: e2e-kind-half-real-mariadb
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +41,11 @@ jobs:
       - name: Set up kind
         uses: engineerd/setup-kind@v0.6.2
 
-      - name: Run Helm chart mock e2e on kind
+      - name: Run Helm chart e2e on kind (${{ matrix.name }})
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_APP_RESOURCE: ${{ secrets.FIREBASE_APP_RESOURCE }}
+          GOOGLE_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 }}
         run: |
-          KEEP_ON_FAILURE=false make e2e-kind-mock
+          KEEP_ON_FAILURE=false make ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compose-e2e-mock compose-e2e-mock-pg compose-e2e-mock-mariadb compose-e2e-down compose-e2e-down-pg compose-e2e-down-mariadb audit-load-k6 e2e-kind-mock e2e-kind-half-real e2e-kind-full-real e2e-kind-full-real-prepare e2e-kind-keep e2e-kind-clean act-release-e2e
+.PHONY: compose-e2e-mock compose-e2e-mock-pg compose-e2e-mock-mariadb compose-e2e-down compose-e2e-down-pg compose-e2e-down-mariadb audit-load-k6 e2e-kind-mock e2e-kind-half-real e2e-kind-half-real-pg e2e-kind-half-real-mariadb e2e-kind-full-real e2e-kind-full-real-prepare e2e-kind-keep e2e-kind-clean act-release-e2e
 
 COMPOSE_E2E_BASE_FILES := -f dev/docker-compose.yml -f dev/docker-compose.e2e.yml
 COMPOSE_E2E_FILES := $(COMPOSE_E2E_BASE_FILES) $(COMPOSE_DB_FILE)
@@ -35,6 +35,14 @@ e2e-kind-mock:
 e2e-kind-half-real:
 	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-appcheck-real.sh scripts/e2e-traefik-cors.sh
 	KIND_E2E_MODE=half-real ./scripts/helm-e2e-kind.sh
+
+e2e-kind-half-real-pg:
+	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-appcheck-real.sh scripts/e2e-traefik-cors.sh
+	KIND_E2E_MODE=half-real KIND_E2E_AUDIT_STORAGE=postgres ./scripts/helm-e2e-kind.sh
+
+e2e-kind-half-real-mariadb:
+	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-appcheck-real.sh scripts/e2e-traefik-cors.sh
+	KIND_E2E_MODE=half-real KIND_E2E_AUDIT_STORAGE=mariadb ./scripts/helm-e2e-kind.sh
 
 e2e-kind-full-real:
 	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-appcheck-real.sh scripts/e2e-traefik-cors.sh

--- a/deploy/chart/templates/NOTES.txt
+++ b/deploy/chart/templates/NOTES.txt
@@ -17,6 +17,9 @@ Admin dashboard: disabled
 Admin API: disabled
 {{- end }}
 
+{{- $auditStorageType := lower (trim (printf "%v" (default "sqlite" (index .Values.config "AUDIT_STORAGE_TYPE")))) }}
+Audit storage: {{ $auditStorageType }}
+{{- if eq $auditStorageType "sqlite" }}
 Audit SQLite path: {{ printf "%v" (default "/var/lib/turnstile-appcheck-gateway/audit.db" (index .Values.config "AUDIT_SQLITE_PATH")) }}
 Persistence:
   Enabled: {{ .Values.persistence.enabled }}
@@ -26,6 +29,9 @@ Persistence:
   {{- else }}
   Backend: emptyDir (audit history is lost when the Pod restarts)
   {{- end }}
+{{- else }}
+Audit DSN source: AUDIT_DSN secret key
+{{- end }}
 
 {{- if .Values.ingress.enabled }}
 Ingress URLs:

--- a/docs/e2e-and-release.md
+++ b/docs/e2e-and-release.md
@@ -4,20 +4,22 @@
 
 This document is for contributors and operators who need to run e2e tests, validate the Helm chart, or understand release automation. 
 
-### PR mock e2e
+### PR Helm e2e
 
-Pull Request CI uses mock mode. It does not contact real Cloudflare Turnstile or Firebase App Check.
+Pull Request CI runs Helm e2e on kind. The mock SQLite path does not contact real Cloudflare Turnstile or Firebase App Check. PostgreSQL and MariaDB variants run half-real mode with dummy Turnstile + real Firebase.
 
 Commands:
 
 ```bash
 make e2e-kind-mock
+make e2e-kind-half-real-pg
+make e2e-kind-half-real-mariadb
 ```
 
 For k6 audit storage load tests, see [Load Testing](load-testing.md).
 
-`e2e-kind-mock` uses a repository-local kubeconfig under `.tmp/` and never targets `~/.kube/config`.
-It installs Traefik in the kind cluster, routes all smoke checks through Traefik, and verifies protected-route CORS behavior for same-origin requests, allowed cross-origin preflight, allowed cross-origin requests, denied origins, and spoofed `X-Forwarded-Method` bypass attempts.
+The kind e2e scripts use a repository-local kubeconfig under `.tmp/` and never target `~/.kube/config`.
+They install Traefik in the kind cluster, route checks through Traefik, and verify protected-route CORS behavior for same-origin requests, allowed cross-origin preflight, allowed cross-origin requests, denied origins, and spoofed `X-Forwarded-Method` bypass attempts.
 
 Keep the kind cluster:
 
@@ -60,8 +62,12 @@ Commands:
 ```bash
 make e2e-kind-mock
 make e2e-kind-half-real
+make e2e-kind-half-real-pg
+make e2e-kind-half-real-mariadb
 REAL_E2E_TURNSTILE_TOKEN='...' make e2e-kind-full-real
 ```
+
+`e2e-kind-half-real` uses SQLite with `emptyDir`. The `-pg` and `-mariadb` targets create an ephemeral database Deployment and configure the chart with `AUDIT_STORAGE_TYPE` and `AUDIT_DSN`.
 
 If you need to obtain a real Turnstile token in a browser first, prepare the local kind frontend:
 
@@ -172,20 +178,22 @@ Notes:
 
 このドキュメントは、e2e test、Helm chart 検証、release automation を扱う contributor / operator 向けです。
 
-### PR 用 mock e2e
+### PR 用 Helm e2e
 
-Pull Request CI は mock mode を使います。real Cloudflare Turnstile / Firebase App Check には接続しません。
+Pull Request CI は kind 上の Helm e2e を実行します。mock SQLite path は real Cloudflare Turnstile / Firebase App Check には接続しません。PostgreSQL / MariaDB variant は dummy Turnstile + real Firebase の half-real mode で実行します。
 
 実行コマンド:
 
 ```bash
 make e2e-kind-mock
+make e2e-kind-half-real-pg
+make e2e-kind-half-real-mariadb
 ```
 
 k6 による audit storage load test は [Load Testing](load-testing.md) を参照してください。
 
-`e2e-kind-mock` は `.tmp/` 配下の repo-local kubeconfig を使い、`~/.kube/config` は使いません。
-kind cluster 内に Traefik を install し、smoke check は Traefik 経由で実行します。protected route の CORS 挙動として same-origin request、allowed cross-origin preflight、allowed cross-origin request、denied origin、`X-Forwarded-Method` spoofing による bypass 試行を検証します。
+kind e2e script は `.tmp/` 配下の repo-local kubeconfig を使い、`~/.kube/config` は使いません。
+kind cluster 内に Traefik を install し、check は Traefik 経由で実行します。protected route の CORS 挙動として same-origin request、allowed cross-origin preflight、allowed cross-origin request、denied origin、`X-Forwarded-Method` spoofing による bypass 試行を検証します。
 
 kind cluster を残す:
 
@@ -228,8 +236,12 @@ mode:
 ```bash
 make e2e-kind-mock
 make e2e-kind-half-real
+make e2e-kind-half-real-pg
+make e2e-kind-half-real-mariadb
 REAL_E2E_TURNSTILE_TOKEN='...' make e2e-kind-full-real
 ```
+
+`e2e-kind-half-real` は SQLite + `emptyDir` を使います。`-pg` / `-mariadb` target は ephemeral な database Deployment を作成し、chart に `AUDIT_STORAGE_TYPE` と `AUDIT_DSN` を設定します。
 
 browser で real Turnstile token を先に取得する場合は、local kind frontend を準備します。
 

--- a/scripts/helm-e2e-kind.sh
+++ b/scripts/helm-e2e-kind.sh
@@ -14,6 +14,7 @@ KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/.tmp/kind-${CLUSTER_NAME}.kubeco
 KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
 KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
 KIND_E2E_MODE="${KIND_E2E_MODE:-mock}"
+KIND_E2E_AUDIT_STORAGE="${KIND_E2E_AUDIT_STORAGE:-sqlite}"
 ENV_FILE="${ENV_FILE:-}"
 FULL_REAL_RUN_LOCAL_PORT="${FULL_REAL_RUN_LOCAL_PORT:-18081}"
 PORT_FORWARD_PID=""
@@ -27,6 +28,7 @@ TURNSTILE_MODE_DETAIL=""
 APP_CHECK_TOKEN=""
 APP_CHECK_TOKEN_FILE=""
 VALUES_FILE=""
+AUDIT_DSN_EFFECTIVE=""
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -44,6 +46,15 @@ case "${KIND_E2E_MODE}" in
     ;;
   *)
     echo "KIND_E2E_MODE must be one of: mock, half-real, full-real, full-real-prepare" >&2
+    exit 1
+    ;;
+esac
+
+case "${KIND_E2E_AUDIT_STORAGE}" in
+  sqlite|postgres|mariadb)
+    ;;
+  *)
+    echo "KIND_E2E_AUDIT_STORAGE must be one of: sqlite, postgres, mariadb" >&2
     exit 1
     ;;
 esac
@@ -118,6 +129,8 @@ debug_dump() {
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get all || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get ingressroute,middleware || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" get events --sort-by=.lastTimestamp || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" logs deploy/audit-postgres || true
+  kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" logs deploy/audit-mariadb || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" describe deploy "${RELEASE_NAME}" || true
   kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" logs deploy/"${RELEASE_NAME}" || true
   helm --kubeconfig "${KUBECONFIG_PATH}" status "${RELEASE_NAME}" -n "${NAMESPACE}" || true
@@ -152,6 +165,20 @@ cleanup() {
   exit "${exit_code}"
 }
 trap cleanup EXIT
+
+configure_audit_storage() {
+  case "${KIND_E2E_AUDIT_STORAGE}" in
+    sqlite)
+      AUDIT_DSN_EFFECTIVE=""
+      ;;
+    postgres)
+      AUDIT_DSN_EFFECTIVE="postgres://turnstile:turnstile@audit-postgres.${NAMESPACE}.svc.cluster.local:5432/turnstile_appcheck_gateway?sslmode=disable"
+      ;;
+    mariadb)
+      AUDIT_DSN_EFFECTIVE="turnstile:turnstile@tcp(audit-mariadb.${NAMESPACE}.svc.cluster.local:3306)/turnstile_appcheck_gateway?parseTime=true&charset=utf8mb4&loc=UTC"
+      ;;
+  esac
+}
 
 configure_real_mode() {
   resolve_env_file || true
@@ -193,6 +220,8 @@ write_values_file() {
   export FIREBASE_APP_ID_EFFECTIVE="${FIREBASE_APP_ID_EFFECTIVE:-}"
   export FIREBASE_APP_RESOURCE_EFFECTIVE="${FIREBASE_APP_RESOURCE_EFFECTIVE:-}"
   export GOOGLE_SERVICE_ACCOUNT_JSON_BASE64_EFFECTIVE="${GOOGLE_SERVICE_ACCOUNT_JSON_BASE64_EFFECTIVE:-}"
+  export KIND_E2E_AUDIT_STORAGE
+  export AUDIT_DSN_EFFECTIVE="${AUDIT_DSN_EFFECTIVE:-}"
 
   python3 - "${VALUES_FILE}" <<'PY'
 import json
@@ -204,6 +233,7 @@ mode = os.environ["KIND_E2E_MODE"]
 config = {
     "ADMIN_AUTH_MODE": "header",
     "ADMIN_ALLOWED_GROUPS": "gateway-admins",
+    "AUDIT_STORAGE_TYPE": os.environ["KIND_E2E_AUDIT_STORAGE"],
     "RATE_LIMIT_ENABLED": "false",
 }
 secrets = {
@@ -231,6 +261,10 @@ else:
         "TURNSTILE_SECRET_KEY": os.environ["TURNSTILE_SECRET_KEY_EFFECTIVE"],
         "GOOGLE_SERVICE_ACCOUNT_JSON_BASE64": os.environ["GOOGLE_SERVICE_ACCOUNT_JSON_BASE64_EFFECTIVE"],
     }
+
+audit_dsn = os.environ.get("AUDIT_DSN_EFFECTIVE", "")
+if audit_dsn:
+    secrets["AUDIT_DSN"] = audit_dsn
 
 def dump_map(name, values):
     print(f"{name}:")
@@ -263,6 +297,7 @@ check_k8s_logs_for_secret() {
   for marker in \
     "${TURNSTILE_SECRET_KEY_EFFECTIVE:-}" \
     "${GOOGLE_SERVICE_ACCOUNT_JSON_BASE64_EFFECTIVE:-}" \
+    "${AUDIT_DSN_EFFECTIVE:-}" \
     "${TURNSTILE_EXCHANGE_TOKEN:-}" \
     "${APP_CHECK_TOKEN:-}"; do
     if [[ -n "${marker}" ]] && grep -Fq "${marker}" "${log_file}"; then
@@ -271,6 +306,142 @@ check_k8s_logs_for_secret() {
     fi
   done
   rm -f "${log_file}"
+}
+
+apply_audit_database() {
+  case "${KIND_E2E_AUDIT_STORAGE}" in
+    sqlite)
+      return 0
+      ;;
+    postgres)
+      kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit-postgres
+  labels:
+    app.kubernetes.io/name: audit-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: audit-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: audit-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: turnstile_appcheck_gateway
+            - name: POSTGRES_USER
+              value: turnstile
+            - name: POSTGRES_PASSWORD
+              value: turnstile
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - turnstile
+                - -d
+                - turnstile_appcheck_gateway
+            initialDelaySeconds: 3
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: audit-postgres
+spec:
+  selector:
+    app.kubernetes.io/name: audit-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+EOF
+      kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" rollout status deploy/audit-postgres --timeout=5m
+      ;;
+    mariadb)
+      kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit-mariadb
+  labels:
+    app.kubernetes.io/name: audit-mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: audit-mariadb
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: audit-mariadb
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:11.4
+          ports:
+            - containerPort: 3306
+              name: mariadb
+          env:
+            - name: MARIADB_DATABASE
+              value: turnstile_appcheck_gateway
+            - name: MARIADB_USER
+              value: turnstile
+            - name: MARIADB_PASSWORD
+              value: turnstile
+            - name: MARIADB_ROOT_PASSWORD
+              value: root
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - mariadb-admin ping -h 127.0.0.1 -uturnstile -pturnstile --silent
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: audit-mariadb
+spec:
+  selector:
+    app.kubernetes.io/name: audit-mariadb
+  ports:
+    - name: mariadb
+      port: 3306
+      targetPort: mariadb
+EOF
+      kubectl --kubeconfig "${KUBECONFIG_PATH}" -n "${NAMESPACE}" rollout status deploy/audit-mariadb --timeout=5m
+      ;;
+  esac
 }
 
 apply_full_real_prepare_frontend() {
@@ -374,12 +545,14 @@ helm lint "${ROOT_DIR}/deploy/chart" \
   --set-string secrets.TURNSTILE_SECRET_KEY=dummy \
   --set-string secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=dummy
 
+configure_audit_storage
 if [[ "${KIND_E2E_MODE}" != "mock" ]]; then
   configure_real_mode
 fi
 write_values_file
 
 echo "kind e2e mode: ${KIND_E2E_MODE}"
+echo "kind audit storage: ${KIND_E2E_AUDIT_STORAGE}"
 
 if kind get clusters | grep -Fxq "${CLUSTER_NAME}"; then
   kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_PATH}"
@@ -398,6 +571,8 @@ kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace "${NAMESPACE}" --dry-
 
 kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace "${TRAEFIK_NAMESPACE}" --dry-run=client -o yaml | \
   kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f -
+
+apply_audit_database
 
 if ! helm repo list | awk '{print $1}' | grep -Fxq traefik; then
   helm repo add traefik https://traefik.github.io/charts


### PR DESCRIPTION
### Summary
- English
  - Add kind Helm e2e variants for PostgreSQL and MariaDB audit backends.
  - Run mock SQLite, half-real PostgreSQL, and half-real MariaDB variants in the pull request Helm e2e workflow.
  - Close #33
- Japanese
  - PostgreSQL / MariaDB audit backend 向けの kind Helm e2e variant を追加します。
  - pull request の Helm e2e workflow で mock SQLite、half-real PostgreSQL、half-real MariaDB variant を実行します。
  - Close #33
### Why
- English
  - The production-like kind e2e should also cover Helm audit database integration, not only the default SQLite path.
  - Exercising `AUDIT_STORAGE_TYPE` and secret-backed `AUDIT_DSN` in CI reduces release risk for PostgreSQL and MariaDB deployments.
- Japanese
  - production-like kind e2e では、既定の SQLite だけでなく Helm の audit database 連携も検証すべきです。
  - `AUDIT_STORAGE_TYPE` と secret-backed `AUDIT_DSN` を CI で検証することで、PostgreSQL / MariaDB deployment の release risk を下げます。