### PR TITLE
Remove admin dashboard user indicator border

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -359,7 +359,7 @@
     <div class="flex min-h-screen flex-1 flex-col lg:pl-64">
       <header class="sticky top-0 z-20 flex min-h-16 items-center justify-end border-b border-slate-200 bg-slate-100/95 px-4 backdrop-blur sm:px-6 lg:px-8">
         {#if me}
-          <div class="inline-flex min-w-0 items-center gap-3 rounded-full border border-slate-200 bg-white px-3 py-2 shadow-sm">
+          <div class="inline-flex min-w-0 items-center gap-3 px-3 py-2">
             <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-50 text-cyan-700">
               <Icon icon="lets-icons:user" class="h-5 w-5" />
             </span>


### PR DESCRIPTION
### Summary
- English
  - Removes the outer border, white pill background, and shadow from the admin dashboard user identity area.
- Japanese
  - admin dashboard のユーザ表示領域から外側の枠、白背景、影を削除します。
### Why
- English
  - Keeps the header identity display visually lightweight and avoids making it look like a separate control.
- Japanese
  - ヘッダー上のユーザ表示を軽量に見せ、独立した操作部品のように見えないようにするためです。

Closes #37