### PR TITLE
Add admin version dialog and e2e browser auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ e2e-kind-full-real-prepare:
 
 e2e-kind-keep:
 	chmod +x scripts/helm-e2e-kind.sh scripts/e2e-smoke-mock.sh scripts/e2e-appcheck-real.sh scripts/e2e-traefik-cors.sh
-	KEEP_CLUSTER=true ./scripts/helm-e2e-kind.sh
+	KEEP_CLUSTER=true E2E_ADMIN_BROWSER_AUTH=true E2E_BUILD_VERSION=0.1.0 E2E_BUILD_COMMIT=0123456789abcdef0123456789abcdef01234567 ./scripts/helm-e2e-kind.sh
 
 e2e-kind-clean:
 	kind delete cluster --name turnstile-appcheck-gateway-e2e || true

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Authentication modes:
 
 Audit logging intentionally avoids sensitive data. It records operational metadata such as timestamp, actor, action, method, path, endpoint, result, status code, request ID, duration, remote address, user agent summary, high-level error code/message, `limitedUse`, and upstream service name. It does not store Turnstile secret keys, submitted Turnstile response tokens, Firebase App Check tokens, Firebase custom tokens, service account JSON, Authorization headers, cookies, raw request bodies, or full external API responses.
 
-The dashboard displays build version and commit hash. Pass `BUILD_VERSION` and `BUILD_COMMIT` during Docker build to populate the sidebar version and GitHub commit link.
+The dashboard displays build version in the sidebar and mobile menu, with commit hash available in the application information dialog. Pass `BUILD_VERSION` and `BUILD_COMMIT` during Docker build to populate the version, commit hash, and release tag link.
 
 ### Firebase Web CustomProvider
 
@@ -575,7 +575,7 @@ Dashboard の request metrics は async rollup counter を使うため、sample 
 
 audit logging は機密情報を保存しない設計です。記録するのは timestamp、actor、action、method、path、endpoint、result、status code、request ID、duration、remote address、user agent summary、高レベルな error code/message、`limitedUse`、upstream service name などの運用 metadata です。Turnstile secret key、送信された Turnstile response token、Firebase App Check token、Firebase custom token、service account JSON、Authorization header、cookie、raw request body、full external API response は保存しません。
 
-dashboard には build version と commit hash が表示されます。Docker build 時に `BUILD_VERSION` と `BUILD_COMMIT` を渡すと、sidebar の version と GitHub commit link に反映されます。
+dashboard は sidebar と mobile menu に build version を表示し、application information dialog で commit hash を確認できます。Docker build 時に `BUILD_VERSION` と `BUILD_COMMIT` を渡すと、version、commit hash、release tag link に反映されます。
 
 ### Firebase Web CustomProvider
 

--- a/docs/e2e-and-release.md
+++ b/docs/e2e-and-release.md
@@ -27,6 +27,17 @@ Keep the kind cluster:
 KEEP_CLUSTER=true make e2e-kind-mock
 ```
 
+The convenience target for browser inspection keeps the cluster and injects e2e-only admin identity headers through Traefik for `/appcheck/admin` and `/appcheck/_admin`:
+
+```bash
+make e2e-kind-keep
+kubectl --kubeconfig .tmp/kind-turnstile-appcheck-gateway-e2e.kubeconfig \
+  -n traefik-e2e port-forward --address 127.0.0.1 svc/traefik 18080:80
+```
+
+Then open `http://127.0.0.1:18080/appcheck/admin/`.
+This target also passes dummy Docker build args, `BUILD_VERSION=0.1.0` and `BUILD_COMMIT=0123456789abcdef0123456789abcdef01234567`, so the admin application information dialog can show the release GitHub icon and git hash without needing a real release build.
+
 Cleanup:
 
 ```bash
@@ -200,6 +211,17 @@ kind cluster を残す:
 ```bash
 KEEP_CLUSTER=true make e2e-kind-mock
 ```
+
+browser で admin 画面を確認する場合は、便利 target が cluster を残し、`/appcheck/admin` と `/appcheck/_admin` に対して e2e 専用の admin identity header を Traefik で注入します。
+
+```bash
+make e2e-kind-keep
+kubectl --kubeconfig .tmp/kind-turnstile-appcheck-gateway-e2e.kubeconfig \
+  -n traefik-e2e port-forward --address 127.0.0.1 svc/traefik 18080:80
+```
+
+その後 `http://127.0.0.1:18080/appcheck/admin/` を開きます。
+この target は dummy Docker build args として `BUILD_VERSION=0.1.0`、`BUILD_COMMIT=0123456789abcdef0123456789abcdef01234567` も渡すため、real release build なしで admin の application information dialog に release GitHub icon と git hash を表示できます。
 
 cleanup:
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -83,6 +83,7 @@
   let resetConfirmation = '';
   let resetReason = '';
   let resetting = false;
+  let aboutOpen = false;
   let loading = true;
   let metricsLoading = false;
   let auditLoading = false;
@@ -118,6 +119,7 @@
   $: brandWordmark = isDarkTheme ? './turnstile-appcheck-gateway-logo-str-dark.svg' : './turnstile-appcheck-gateway-logo-str.svg';
   $: pageTitle = activeView === 'audit' ? 'Audit Log' : 'Dashboard';
   $: pageDescription = activeView === 'audit' ? 'Search, inspect, and reset gateway audit events.' : 'Monitor gateway request health and traffic trends.';
+  $: releaseTagURL = me?.releaseTagURL ?? '';
   $: chartTextColor = isDarkTheme ? '#CBD5E1' : '#475569';
   $: chartGridColor = isDarkTheme ? 'rgba(148, 163, 184, 0.24)' : 'rgba(203, 213, 225, 0.7)';
   $: chartSurfaceColor = isDarkTheme ? '#0F172A' : '#FFFFFF';
@@ -351,6 +353,7 @@
     mobileMenuOpen = false;
     if (detailOpen) detailOpen = false;
     if (resetOpen && !resetting) resetOpen = false;
+    if (aboutOpen) aboutOpen = false;
   }
 
   async function changePageSize() {
@@ -422,6 +425,12 @@
     resetOpen = true;
   }
 
+  function openAboutModal() {
+    aboutOpen = true;
+    mobileMenuOpen = false;
+    themeMenuOpen = false;
+  }
+
   async function resetAuditLog() {
     resetting = true;
     error = '';
@@ -481,7 +490,13 @@
       </button>
     </nav>
 
-    <div class="admin-sidebar-collapse">
+    <div class="admin-sidebar-footer">
+      {#if me && !sidebarCollapsed}
+        <button class="app-info-trigger" type="button" aria-label="Open application information" onclick={openAboutModal}>
+          <Icon icon="lucide:info" class="h-4 w-4 shrink-0" />
+          <span class="truncate">Version {me.version}</span>
+        </button>
+      {/if}
       <button
         class="icon-button sidebar-toggle-button"
         aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
@@ -491,19 +506,6 @@
       >
         <Icon icon={sidebarCollapsed ? 'lucide:panel-left-open' : 'lucide:panel-left-close'} class="h-5 w-5" />
       </button>
-    </div>
-
-    <div class="admin-sidebar-footer">
-      {#if me && !sidebarCollapsed}
-        {#if me.commitURL}
-          <a class="inline-flex max-w-full items-center gap-1.5 truncate hover:underline" href={me.commitURL} target="_blank" rel="noreferrer">
-            <Icon icon="mdi:github" class="h-4 w-4 shrink-0" />
-            <span class="truncate">{me.shortCommit}</span>
-          </a>
-        {:else}
-          <span class="truncate">Commit {me.shortCommit}</span>
-        {/if}
-      {/if}
     </div>
   </aside>
 
@@ -597,6 +599,14 @@
               <span>Audit Log</span>
             </button>
           </div>
+          {#if me}
+            <div class="mobile-menu-footer">
+              <button class="app-info-trigger" type="button" aria-label="Open application information" onclick={openAboutModal}>
+                <Icon icon="lucide:info" class="h-4 w-4 shrink-0" />
+                <span class="truncate">Version {me.version}</span>
+              </button>
+            </div>
+          {/if}
         </div>
       </div>
     {/if}
@@ -922,6 +932,43 @@
     <div class="loading-indicator">
       <span class="loading-spinner" aria-hidden="true"></span>
       <span role="status" aria-live="polite">Loading dashboard</span>
+    </div>
+  </div>
+{/if}
+
+{#if aboutOpen && me}
+  <div class="modal-backdrop" role="presentation">
+    <div class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="about-app-title">
+      <div class="modal-header">
+        <h2 id="about-app-title" class="text-base font-semibold">About This Application</h2>
+        <div class="modal-header-actions">
+          {#if releaseTagURL}
+            <a class="icon-button" aria-label="Open release tag on GitHub" title="Open release tag on GitHub" href={releaseTagURL} target="_blank" rel="noreferrer">
+              <Icon icon="bi:github" class="h-5 w-5" />
+            </a>
+          {/if}
+          <button class="icon-button" aria-label="Close application information" title="Close" onclick={() => (aboutOpen = false)}>
+            <Icon icon="lets-icons:close-round" class="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+      <div class="modal-body space-y-4">
+        <p class="text-sm text-[var(--text-secondary)]">Admin dashboard for monitoring Turnstile and Firebase App Check gateway activity.</p>
+        <dl class="about-metadata">
+          <div>
+            <dt>Application</dt>
+            <dd>{appName}</dd>
+          </div>
+          <div>
+            <dt>Build version</dt>
+            <dd>{me.version}</dd>
+          </div>
+          <div>
+            <dt>Git hash</dt>
+            <dd>{me.commit}</dd>
+          </div>
+        </dl>
+      </div>
     </div>
   </div>
 {/if}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,7 @@ export type AdminMe = {
   commit: string;
   shortCommit: string;
   commitURL: string;
+  releaseTagURL: string;
   auditTimestampFormat: string;
 };
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -141,26 +141,49 @@ textarea:focus-visible {
   padding-inline: 0;
 }
 
-.admin-sidebar-collapse {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: auto;
-  padding: 10px;
-}
-
-.admin-shell.sidebar-collapsed .admin-sidebar-collapse {
-  justify-content: center;
-}
-
 .sidebar-toggle-button {
+  flex: 0 0 auto;
   color: var(--text-secondary);
 }
 
 .admin-sidebar-footer {
+  display: flex;
+  min-height: 65px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: auto;
   border-top: 1px solid var(--border-color);
-  padding: 16px 20px;
+  padding: 10px;
   color: var(--text-secondary);
   font-size: 14px;
+}
+
+.admin-shell.sidebar-collapsed .admin-sidebar-footer {
+  justify-content: center;
+}
+
+.app-info-trigger {
+  display: inline-flex;
+  min-width: 0;
+  min-height: 44px;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 8px;
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 650;
+  text-align: left;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.app-info-trigger:hover {
+  background: var(--surface-elevated);
+  color: var(--focus-ring);
 }
 
 .admin-topbar {
@@ -317,11 +340,19 @@ textarea:focus-visible {
 }
 
 .mobile-menu-panel {
+  display: flex;
+  flex-direction: column;
   width: min(360px, 92vw);
   min-height: 100vh;
   background: var(--surface-bg);
   color: var(--text-primary);
   box-shadow: 0 24px 60px rgb(0 0 0 / 0.28);
+}
+
+.mobile-menu-footer {
+  margin-top: auto;
+  border-top: 1px solid var(--border-color);
+  padding: 12px;
 }
 
 .panel,
@@ -586,8 +617,37 @@ textarea:focus-visible {
   padding: 16px 20px;
 }
 
+.modal-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .modal-body {
   padding: 20px;
+}
+
+.about-metadata {
+  display: grid;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.about-metadata div {
+  display: grid;
+  gap: 4px;
+}
+
+.about-metadata dt {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.about-metadata dd {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-weight: 650;
 }
 
 .danger-callout {

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -59,6 +59,34 @@ func TestHeaderAuthAllowDenyAndMe(t *testing.T) {
 	}
 }
 
+func TestReleaseTagURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "docker tag version",
+			value: "1.2.3",
+			want:  "https://github.com/michibiki-io/turnstile-appcheck-gateway/releases/tag/v1.2.3",
+		},
+		{
+			name:  "git tag version",
+			value: "v1.2.3",
+			want:  "https://github.com/michibiki-io/turnstile-appcheck-gateway/releases/tag/v1.2.3",
+		},
+		{name: "dev", value: "dev", want: ""},
+		{name: "non semver", value: "main", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := releaseTagURL(tt.value); got != tt.want {
+				t.Fatalf("releaseTagURL(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNoneAuthAndTimestampFormatting(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := testConfig(t)

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -24,6 +24,7 @@ func (h *Handler) me(c *gin.Context) {
 		"commit":               version.Commit(),
 		"shortCommit":          version.ShortCommit(),
 		"commitURL":            commitURL(version.Commit()),
+		"releaseTagURL":        releaseTagURL(version.Value()),
 		"auditTimestampFormat": h.cfg.Admin.Dashboard.TimestampFormat,
 	})
 }
@@ -183,6 +184,27 @@ func commitURL(commit string) string {
 		return ""
 	}
 	return "https://github.com/michibiki-io/turnstile-appcheck-gateway/commit/" + commit
+}
+
+func releaseTagURL(buildVersion string) string {
+	tag := strings.TrimSpace(buildVersion)
+	if tag == "" || tag == "dev" {
+		return ""
+	}
+	if !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+	parts := strings.Split(strings.TrimPrefix(tag, "v"), ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	for _, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil || value < 0 {
+			return ""
+		}
+	}
+	return "https://github.com/michibiki-io/turnstile-appcheck-gateway/releases/tag/" + tag
 }
 
 func (h *Handler) auditReset(c *gin.Context) {

--- a/scripts/helm-e2e-kind.sh
+++ b/scripts/helm-e2e-kind.sh
@@ -6,6 +6,8 @@ CLUSTER_NAME="${CLUSTER_NAME:-turnstile-appcheck-gateway-e2e}"
 NAMESPACE="${NAMESPACE:-appcheck-e2e}"
 RELEASE_NAME="${RELEASE_NAME:-turnstile-appcheck-gateway}"
 IMAGE_NAME="${IMAGE_NAME:-turnstile-appcheck-gateway:e2e}"
+E2E_BUILD_VERSION="${E2E_BUILD_VERSION:-dev}"
+E2E_BUILD_COMMIT="${E2E_BUILD_COMMIT:-unknown}"
 LOCAL_PORT_REQUESTED="${LOCAL_PORT:-}"
 LOCAL_PORT="${LOCAL_PORT_REQUESTED:-18080}"
 TRAEFIK_NAMESPACE="${TRAEFIK_NAMESPACE:-traefik-e2e}"
@@ -14,6 +16,7 @@ ALLOWED_CORS_ORIGIN="${ALLOWED_CORS_ORIGIN:-https://allowed-origin.e2e.test}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/.tmp/kind-${CLUSTER_NAME}.kubeconfig}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
 KEEP_ON_FAILURE="${KEEP_ON_FAILURE:-true}"
+E2E_ADMIN_BROWSER_AUTH="${E2E_ADMIN_BROWSER_AUTH:-false}"
 KIND_E2E_MODE="${KIND_E2E_MODE:-mock}"
 KIND_E2E_AUDIT_STORAGE="${KIND_E2E_AUDIT_STORAGE:-sqlite}"
 ENV_FILE="${ENV_FILE:-}"
@@ -56,6 +59,15 @@ case "${KIND_E2E_AUDIT_STORAGE}" in
     ;;
   *)
     echo "KIND_E2E_AUDIT_STORAGE must be one of: sqlite, postgres, mariadb" >&2
+    exit 1
+    ;;
+esac
+
+case "${E2E_ADMIN_BROWSER_AUTH}" in
+  true|false)
+    ;;
+  *)
+    echo "E2E_ADMIN_BROWSER_AUTH must be true or false" >&2
     exit 1
     ;;
 esac
@@ -193,6 +205,13 @@ cleanup() {
 
   if [[ ${exit_code} -eq 0 && "${KEEP_CLUSTER}" == "true" ]]; then
     echo "kind resources preserved after success" >&2
+    if [[ "${E2E_ADMIN_BROWSER_AUTH}" == "true" ]]; then
+      echo "admin browser auth is enabled for this e2e cluster" >&2
+      echo "run this port-forward to open the admin dashboard:" >&2
+      echo "  kubectl --kubeconfig ${KUBECONFIG_PATH} -n ${TRAEFIK_NAMESPACE} port-forward --address 127.0.0.1 svc/${TRAEFIK_RELEASE_NAME} ${LOCAL_PORT}:80" >&2
+      echo "then open:" >&2
+      echo "  http://127.0.0.1:${LOCAL_PORT}/appcheck/admin/" >&2
+    fi
     exit 0
   fi
 
@@ -342,6 +361,42 @@ check_k8s_logs_for_secret() {
     fi
   done
   rm -f "${log_file}"
+}
+
+admin_browser_auth_documents() {
+  if [[ "${E2E_ADMIN_BROWSER_AUTH}" != "true" ]]; then
+    return 0
+  fi
+
+  cat <<'EOF'
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: e2e-admin-browser-auth
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-User: e2e-admin
+      X-Forwarded-Email: e2e-admin@example.com
+      X-Forwarded-Groups: gateway-admins
+EOF
+}
+
+admin_browser_auth_routes() {
+  if [[ "${E2E_ADMIN_BROWSER_AUTH}" != "true" ]]; then
+    return 0
+  fi
+
+  cat <<EOF
+    - kind: Rule
+      match: PathPrefix(\`/appcheck/admin\`) || PathPrefix(\`/appcheck/_admin\`)
+      middlewares:
+        - name: e2e-admin-browser-auth
+      services:
+        - name: ${RELEASE_NAME}
+          port: 80
+EOF
 }
 
 wait_for_traefik_mx_api_route() {
@@ -625,6 +680,8 @@ write_values_file
 
 echo "kind e2e mode: ${KIND_E2E_MODE}"
 echo "kind audit storage: ${KIND_E2E_AUDIT_STORAGE}"
+echo "kind build version: ${E2E_BUILD_VERSION}"
+echo "kind build commit: ${E2E_BUILD_COMMIT}"
 choose_local_port
 echo "kind local port: ${LOCAL_PORT}"
 
@@ -637,7 +694,11 @@ chmod 600 "${KUBECONFIG_PATH}"
 
 kubectl --kubeconfig "${KUBECONFIG_PATH}" get nodes
 
-docker build -t "${IMAGE_NAME}" "${ROOT_DIR}"
+docker build \
+  --build-arg BUILD_VERSION="${E2E_BUILD_VERSION}" \
+  --build-arg BUILD_COMMIT="${E2E_BUILD_COMMIT}" \
+  -t "${IMAGE_NAME}" \
+  "${ROOT_DIR}"
 kind load docker-image "${IMAGE_NAME}" --name "${CLUSTER_NAME}"
 
 kubectl --kubeconfig "${KUBECONFIG_PATH}" create namespace "${NAMESPACE}" --dry-run=client -o yaml | \
@@ -732,6 +793,7 @@ spec:
       - X-Firebase-AppCheck
     accessControlMaxAge: 86400
     addVaryHeader: true
+$(admin_browser_auth_documents)
 ---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
@@ -762,6 +824,7 @@ spec:
   entryPoints:
     - web
   routes:
+$(admin_browser_auth_routes)
     - kind: Rule
       match: PathPrefix(\`/appcheck\`)
       services:


### PR DESCRIPTION
### Summary
- English
  - Replace the sidebar commit hash footer with a version entry that opens an application information dialog.
  - Add release tag URL metadata and e2e keep support for browser-based admin dashboard inspection.
- Japanese
  - sidebar footer の commit hash 直表示を、application information dialog を開く version entry に置き換えます。
  - release tag URL metadata と、browser で admin dashboard を確認するための e2e keep support を追加します。

### Why
- English
  - Admin build metadata should be visible in a consistent, accessible dialog and verifiable in a kept kind e2e environment.
- Japanese
  - admin build metadata は一貫した accessible dialog で表示し、keep した kind e2e 環境で検証できる必要があります。

Close #43
